### PR TITLE
docs: move section navigation from the header into a left-sidebar tree

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -15,3 +15,35 @@ dl.py {
   margin: 0;
   font-weight: 600;
 }
+
+/* Structured navigation tree in the left sidebar (rendered from the global
+   toctree). Style the plain <ul>/<li> like a proper sidebar nav. */
+.bd-sidebar-primary .bd-toc-item ul {
+  list-style: none;
+  padding-left: 0;
+  margin-bottom: 0.5rem;
+}
+.bd-sidebar-primary .bd-toc-item ul ul {
+  padding-left: 1rem;
+}
+.bd-sidebar-primary .bd-toc-item li > a {
+  display: block;
+  padding: 0.2rem 0;
+  color: var(--pst-color-text-muted);
+  text-decoration: none;
+}
+.bd-sidebar-primary .bd-toc-item li > a:hover {
+  color: var(--pst-color-primary);
+}
+.bd-sidebar-primary .bd-toc-item li.current > a.current {
+  color: var(--pst-color-primary);
+  font-weight: 600;
+}
+.bd-sidebar-primary .bd-toc-item .caption {
+  margin-top: 1rem;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--pst-color-text-base);
+}

--- a/docs/_templates/sidebar-tree.html
+++ b/docs/_templates/sidebar-tree.html
@@ -1,0 +1,9 @@
+{# Full site navigation as a structured tree in the left sidebar.
+   Uses Sphinx's global ``toctree()`` so every section (the per-module API
+   pages, getting started, examples) appears here instead of in the header. #}
+<nav class="bd-docs-nav bd-links" aria-label="Section Navigation">
+  <p class="bd-links__title" role="heading" aria-level="1">Site navigation</p>
+  <div class="bd-toc-item navbar-nav">
+    {{ toctree(collapse=False, maxdepth=2, includehidden=True, titles_only=True) }}
+  </div>
+</nav>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,19 +73,20 @@ html_context = {
 html_theme_options = {
     # Wrench-emoji wordmark stands in for any project logo, in the header…
     "logo": {"text": "🔧 combra"},
-    # …and the navbar layout mirrors the scikit-image header:
-    #   left   — wordmark + version dropdown
-    #   center — section navigation
-    #   right  — theme toggle + GitHub icon (search stays pinned)
+    # Header keeps only the wordmark + version dropdown (left) and the
+    # search / theme-toggle / GitHub controls (right). The section
+    # navigation lives in the left sidebar as a structured tree, not in
+    # the header.
     "navbar_start": ["navbar-logo", "version-switcher"],
-    "navbar_center": ["navbar-nav"],
+    "navbar_center": [],
     "navbar_end": ["theme-switcher", "navbar-icon-links"],
     "navbar_persistent": ["search-button"],
-    "header_links_before_dropdown": 6,
     "show_prev_next": True,
     "use_edit_page_button": True,
     "navigation_with_keys": False,
     "collapse_navigation": False,
+    # Expand the left-sidebar tree down to the per-module API pages.
+    "show_nav_level": 2,
     "icon_links": [
         {
             "name": "GitHub",
@@ -102,6 +103,12 @@ html_theme_options = {
     # Footer: combra wordmark on the left, copyright on the right.
     "footer_start": ["footer-brand"],
     "footer_end": ["copyright"],
+}
+
+# Show the structured navigation tree in the left sidebar on every page —
+# including the landing page, where PyData hides it by default.
+html_sidebars = {
+    "**": ["sidebar-tree"],
 }
 
 # Sphinx domain settings.


### PR DESCRIPTION
The per-module sections (combra.data, combra.image, …) and the "More" dropdown were crowding the header. Drop the navbar nav and render the full global toctree as a structured tree in the left sidebar instead:

- navbar_center is now empty; the header keeps only the wordmark + version dropdown (left) and search / theme / GitHub (right).
- A custom sidebar-tree template renders Sphinx's global toctree (captions: Getting started / Python API / Examples) on every page, including the landing page.
- custom.css styles the tree like a proper sidebar nav.