### PR TITLE
Add force_rebuild_cache parameter to generate_angles method

### DIFF
--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -102,7 +102,7 @@ When an h5 lives at `<data>/h5/<stem>.h5`, the cache is written to
 ... )
 ```
 
-````{py:method} generate_angles(save_path, types_dict, step, workers=20, angles_tol=3, min_segment_len=10.0, keep_contours=False, chunksize=64, run_meta=None) -> Path
+````{py:method} generate_angles(save_path, types_dict, step, workers=20, angles_tol=3, min_segment_len=10.0, keep_contours=False, chunksize=64, run_meta=None, force_rebuild_cache=False) -> Path
 
 Compute angle distributions for every image and write them as parquet. One row per
 class; per-step Gaussian-fit results are stored as a list under `prep_per_step`.
@@ -128,6 +128,8 @@ source h5, code commit, generation timestamp, and the exact extraction params us
 :type chunksize: int, optional
 :param run_meta: Caller-supplied provenance. May set `family`, `resolution`, `tags`, `notes`. Everything else (`model_tag`, `kimg`, `source_h5`, `code_commit`, `generated_at`, `extraction_params`) is filled automatically. Default: `None`.
 :type run_meta: dict or None, optional
+:param force_rebuild_cache: If `True`, rebuild the preprocessed-image cache from scratch instead of reusing an existing `.npy` memmap. The reuse check only validates shape and dtype, not the preprocessing version, so a stale cache from older preprocessing is otherwise reused silently — pass `True` to rule that out. Default: `False`.
+:type force_rebuild_cache: bool, optional
 :returns: **out_path** – the written parquet path.
 :rtype: Path
 


### PR DESCRIPTION
## Summary
Added a new optional parameter `force_rebuild_cache` to the `generate_angles` method to allow users to explicitly rebuild the preprocessed-image cache instead of silently reusing potentially stale cached data.

## Changes
- Added `force_rebuild_cache` parameter to the `generate_angles` method signature with a default value of `False`
- Updated the method documentation to explain the new parameter:
  - Describes the purpose: forcing a rebuild of the preprocessed-image cache from scratch
  - Clarifies the motivation: the existing reuse check only validates shape and dtype, not preprocessing version, so stale caches from older preprocessing versions can be silently reused
  - Documents the default behavior and how to opt into cache rebuilding

## Details
This change addresses a potential issue where outdated cached preprocessing could be silently reused if the shape and dtype match, even if the preprocessing algorithm has been updated. Users can now pass `force_rebuild_cache=True` to ensure a fresh cache is generated with the current preprocessing logic.

https://claude.ai/code/session_018wfaN5CH57doDsHQu977KZ