### PR TITLE
docs: add Karpathy skill/CLAUDE.md and sync combra metrics & tests docs

### DIFF
--- a/.claude/skills/karpathy-guidelines/SKILL.md
+++ b/.claude/skills/karpathy-guidelines/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: karpathy-guidelines
+description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+license: MIT
+---
+
+# Karpathy Guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+## About this project
+
+`wc_cv` is the research and documentation repository for **combra** — computer-vision
+tools for analysis of WC-Co (tungsten-carbide / cobalt) composite-alloy microstructure
+SEM images: contour/angle extraction, MVEE beam fitting, fractal dimension, crack
+graphs, and distribution metrics.
+
+- `docs/` is a **Sphinx** site (MyST markdown) that documents the `combra` library API.
+  It is published to GitHub Pages on every push to `main`. Build it locally with:
+  ```bash
+  python -m sphinx -b html docs public
+  ```
+  Doc pages live in `docs/api/*.md` (one per combra submodule), `docs/get_started.md`,
+  and `docs/examples/*.md`. When the combra library changes, keep these pages in sync.
+- `combra` itself is maintained in a **separate repo** (`dkagramanyan/combra`, wired in
+  here as the `combra/` git submodule). Run its test suite from that repo with `pytest`.
+- The top-level notebooks (`co_angles/`, `crack_graph/`, `ml/`, `poliamid/`) are
+  exploratory analyses that exercise the documented combra API.
+
+---
+
+Behavioral guidelines to reduce common LLM coding mistakes, derived from
+[Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876)
+on LLM coding pitfalls. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -317,9 +317,9 @@ Walk every parquet under `folder` (each assumed to be the same generator at a di
 
 Tools that aggregate `metrics_vs_n` records into per-curve statistics (Kendall trend test, endpoint relative error, plateau fit) and turn them into the tables and figures consumed by `3_metrics_convergence.ipynb`.
 
-````{py:function} combra.metrics.convergence_stats(df_metrics, metrics, endpoints_by_kind, expected_points=None) -> pandas.DataFrame
+````{py:function} combra.metrics.convergence_stats(df_metrics, metrics, endpoints_by_kind, expected_points=None, pre_endpoints_by_kind=None) -> pandas.DataFrame
 
-Per `(kind, resolution, class)` curve, compute trend significance, endpoint relative error, and a plateau fit $|m|(N) = a + b \cdot N^{-1/2}$.
+Per `(kind, resolution, class)` curve, compute trend significance, endpoint relative error, a power-law decay exponent, and a plateau fit $|m|(N) = a + b \cdot N^{-1/2}$.
 
 :param df_metrics: Long-form table with columns `kind`, `resolution`, `class`, `n_images`, and one column per metric in `metrics`.
 :type df_metrics: pd.DataFrame
@@ -329,14 +329,19 @@ Per `(kind, resolution, class)` curve, compute trend significance, endpoint rela
 :type endpoints_by_kind: dict[str, tuple[int, int]]
 :param expected_points: `{kind: expected_n_points_per_curve}`. When given, prints a warning if a curve has the wrong count. Default: `None`.
 :type expected_points: dict[str, int] or None, optional
-:returns: **result** (*pd.DataFrame*) – One row per `(kind, resolution, class, metric)`. Columns: `kendall_p`, `rel_err_abs_%`, `m_at_nmax`, `a_hat`, `a_se`, `gain_abs`, `gain_pct`, `vs_a_pct`.
+:param pre_endpoints_by_kind: Optional `{kind: (n_lo, n_hi)}` for an *earlier* N-range (e.g. `360 → 1000` for `san`/`diffit`), reported alongside the main range. The `pre_*` columns are `NaN` for any kind absent from this mapping. Default: `None`.
+:type pre_endpoints_by_kind: dict[str, tuple[int, int]] or None, optional
+:returns: **result** (*pd.DataFrame*) – One row per `(kind, resolution, class, metric)`. Columns: `kendall_p`, `rel_err_abs_%`, `pre_rel_err_abs_%`, `alpha`, `pre_alpha`, `m_at_nhi`, `a_hat`, `a_se`, `b_hat`, `fit_r2`, `gain_abs`, `gain_pct`, `vs_a_pct`.
 :rtype: pandas.DataFrame
 
 The returned columns mean:
 
 - `kendall_p` — one-sided Kendall τ p-value for "|metric| decreases with N".
-- `rel_err_abs_%` — `(|m|@N_lo − |m|@N_hi) / |m|@N_lo × 100`. Positive = improvement between the two N endpoints.
-- `a_hat`, `a_se` — plateau (bias floor) and its standard error from {py:func}`combra.approx.fit_plateau`.
+- `rel_err_abs_%` — `(|m|@N_lo − |m|@N_hi) / |m|@N_lo × 100` over the main endpoints. Positive = improvement between the two N endpoints. `pre_rel_err_abs_%` is the same over `pre_endpoints_by_kind` (`NaN` when no pre pair).
+- `alpha` — power-law decay exponent in `|m| ~ N^(-alpha)`, estimated from the two endpoints as `log(|m|@N_lo / |m|@N_hi) / log(N_hi / N_lo)`. `0.5` is ideal Monte-Carlo decay, `0` means no improvement, `< 0` means |metric| grew with N. `pre_alpha` is the same over the pre endpoints.
+- `m_at_nhi` — `|metric|` at `N_hi`.
+- `a_hat`, `a_se`, `b_hat` — the plateau (bias floor `a`), its standard error, and the `N^{-1/2}` slope `b` from {py:func}`combra.approx.fit_plateau`.
+- `fit_r2` — coefficient of determination of the plateau fit against the observed `|metric|` curve.
 - `gain_pct` — sampling-only gain from `N_hi` to infinity, in percent of `|m|@N_hi`.
 - `vs_a_pct` — excess of `|m|@N_lo` over the bias floor `a_hat`, in percent.
 
@@ -348,19 +353,21 @@ From `co_angles/3_metrics_convergence.ipynb`:
 >>> from combra.metrics import convergence_stats
 >>> METRICS  = ['w_dist', 'mu1', 'mu2', 'sigma1', 'sigma2', 'amp1', 'amp2']
 >>> ENDPTS   = {'real': (100, 300), 'san': (360, 10000), 'diffit': (360, 10000)}
+>>> PRE      = {'san': (360, 1000), 'diffit': (360, 1000)}
 >>> result = convergence_stats(df_metrics, METRICS, ENDPTS,
-...                            expected_points={'real': 5, 'san': 8, 'diffit': 8})
+...                            expected_points={'real': 5, 'san': 8, 'diffit': 8},
+...                            pre_endpoints_by_kind=PRE)
 >>> result.head(3)
 ```
 ````
 
-````{py:function} combra.metrics.print_convergence_report(result, metrics, kinds, endpoints_by_kind, alpha=0.05, step=None, kind_display=None) -> None
+````{py:function} combra.metrics.print_convergence_report(result, metrics, kinds, endpoints_by_kind, alpha=0.05, step=None, kind_display=None, pre_endpoints_by_kind=None) -> None
 
 Print three human-readable tables from a `convergence_stats` result:
 
 - **T1 (kendall_byclass)** — per-class Kendall p-values + `rel_err_abs_%`, with Fisher's combined $\chi^2 = -2 \cdot \sum \log p$ across the 3 classes.
 - **T2 (kendall_fisher_byres)** — per-resolution Fisher across classes; one panel per resolution.
-- **T3 (asymptote)** — plateau-fit summary (`a_gen`, `gain_%`, `vs_a_%`). A trailing `*` on `a_gen` means `a_se >= a` (plateau not yet identified).
+- **T3 (gains+alpha)** — finite-range gain and power-law-exponent columns side by side: `gain_%_a->b = (|m|@a − |m|@b)/|m|@a × 100` (positive = error shrank) and `alpha_a->b = log(|m|@a / |m|@b) / log(b/a)` (`0.5` = ideal Monte-Carlo, `0` = no gain). When `pre_endpoints_by_kind` is given, the pre-range columns are shown next to the main-range ones.
 
 :param result: Output of `convergence_stats`.
 :type result: pd.DataFrame
@@ -376,6 +383,8 @@ Print three human-readable tables from a `convergence_stats` result:
 :type step: float or None, optional
 :param kind_display: Display names (e.g. `{'san': 'SAN', 'diffit': 'DiffiT'}`). Default: `None`.
 :type kind_display: dict[str, str] or None, optional
+:param pre_endpoints_by_kind: Optional `{kind: (n_lo, n_hi)}` earlier-N range; when given, T3 prints its `gain_%`/`alpha` columns alongside the main range. Default: `None`.
+:type pre_endpoints_by_kind: dict[str, tuple[int, int]] or None, optional
 :returns: Nothing. Output goes to stdout.
 :rtype: None
 
@@ -386,6 +395,7 @@ Print three human-readable tables from a `convergence_stats` result:
 >>> print_convergence_report(
 ...     result, METRICS, kinds=['san', 'diffit'],
 ...     endpoints_by_kind={'san': (360, 10000), 'diffit': (360, 10000)},
+...     pre_endpoints_by_kind={'san': (360, 1000), 'diffit': (360, 1000)},
 ...     step=2.0, kind_display={'san': 'SAN', 'diffit': 'DiffiT'},
 ... )
 ```

--- a/docs/api/tests.md
+++ b/docs/api/tests.md
@@ -10,11 +10,21 @@ from combra import tests
 
 ````{py:function} combra.tests.test_fractal_dimensions(sizes) -> None
 
-Validate the box-counting fractal-dimension estimator on canonical fractals with known Hausdorff dimensions — Cantor dust ($\log 4/\log 3 \approx 1.262$), the Sierpiński carpet ($\log 8/\log 3 \approx 1.893$), and the Sierpiński triangle ($\log 3/\log 2 \approx 1.585$) — and compares {py:func}`combra.image.image_fractal_dimension` against each reference value.
+Validate the box-counting fractal-dimension estimator on seven reference shapes with known dimensions and compare {py:func}`combra.image.image_fractal_dimension` against each:
+
+- a single **point** ($D = 0$),
+- a straight **line** ($D = 1$),
+- a **filled square** ($D = 2$),
+- **Cantor dust** ($\log 4/\log 3 \approx 1.262$),
+- the **Sierpiński carpet** ($\log 8/\log 3 \approx 1.893$),
+- the **Sierpiński triangle** ($\log 3/\log 2 \approx 1.585$),
+- the **Koch curve** ($\log 4/\log 3 \approx 1.262$).
+
+For each shape it prints the expected vs. estimated dimension and the relative error, then a final **SUMMARY** line with the average relative error across the non-degenerate shapes (the zero-dimension point is excluded from the average).
 
 :param sizes: Box sizes to sweep (passed through to {py:func}`combra.image.image_fractal_dimension`).
 :type sizes: ndarray or list[int]
-:returns: Nothing. Prints the estimated-vs-expected dimension for each reference fractal.
+:returns: Nothing. Prints the estimated-vs-expected dimension and relative error for each reference shape, followed by the average relative error.
 :rtype: None
 
 **Example**

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -2,13 +2,47 @@
 
 ## Installation
 
-Combra is a standard Python package — all dependencies are pure-pip and install automatically, with no system packages required. combra uses the headless OpenCV build (`opencv-python-headless`), so no `libGL`/`libglib` system libraries are needed; it runs out of the box in minimal containers and HPC environments where you can only install Python packages. From a clone of the repository:
+Combra is a standard Python package — all dependencies are pure-pip and install automatically, with no system packages required. combra uses the headless OpenCV build (`opencv-python-headless`), so no `libGL`/`libglib` system libraries are needed; it runs out of the box in minimal containers and HPC environments where you can only install Python packages.
+
+combra is not on PyPI yet, so install it from source:
 
 ```bash
-pip install -e .
+git clone https://github.com/dkagramanyan/combra.git
+cd combra
+pip install .          # or:  pip install -e .   for an editable install
 ```
 
+### Optional extras
+
+| Extra   | Install                   | Adds                          |
+| ------- | ------------------------- | ----------------------------- |
+| `tests` | `pip install ".[tests]"`  | pytest + pytest-cov           |
+| `docs`  | `pip install ".[docs]"`   | Sphinx docs toolchain         |
+| `dev`   | `pip install -e ".[dev]"` | the `tests` extra + ruff      |
+
 FID metrics work out of the box. `combra.metrics.fid` delegates to [pytorch-fid](https://github.com/mseitzer/pytorch-fid) and [torch-fidelity](https://github.com/toshas/torch-fidelity), which ship as core dependencies and download/cache their own InceptionV3 weights on first use — no manual model setup. `compute_fid` runs on CUDA when available and falls back to CPU; see {doc}`combra.metrics <api/metrics>`.
+
+## Testing
+
+After a development install you can run the full test suite, the linter, and the formatter:
+
+```bash
+pip install -e ".[dev]"
+
+pytest                           # run the test suite
+ruff check combra tests          # lint
+ruff format combra tests         # format
+```
+
+CI (GitHub Actions) runs the ruff lint + format checks and `pytest` on Python 3.10, 3.11, and 3.12.
+
+For a quick post-install sanity check that doesn't need the dev tools, run the bundled self-validation helper — it estimates the fractal dimension of reference shapes with known answers (see {doc}`combra.tests <api/tests>`):
+
+```python
+>>> import numpy as np
+>>> from combra import tests
+>>> tests.test_fractal_dimensions(np.array([2, 3, 4, 6, 8, 12, 16, 24, 32]))
+```
 
 ## Smoke test
 


### PR DESCRIPTION
- Add CLAUDE.md (project preamble + Karpathy coding guidelines) and the
  karpathy-guidelines skill under .claude/skills/.
- metrics: document convergence_stats/print_convergence_report
  pre_endpoints_by_kind param, the new alpha/pre_alpha/pre_rel_err_abs_%/
  b_hat/fit_r2 columns (m_at_nmax -> m_at_nhi), and the T3 gains+alpha table.
- tests: test_fractal_dimensions now validates seven reference shapes
  (point/line/filled square/Cantor dust/Sierpinski carpet+triangle/Koch curve)
  with an average relative-error summary.
- get_started: install-from-source steps, optional-extras table, and a new
  Testing section (pytest/ruff, CI matrix, in-package sanity check).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011Fy3cCr3ETbgYA6YoFERzq