### PR TITLE
docs: Karpathy skill + CLAUDE.md, sync combra metrics/tests docs, image-only FID

### DIFF
--- a/docs/_static/source_index.json
+++ b/docs/_static/source_index.json
@@ -1430,13 +1430,5 @@
   "file": "combra/metrics/fid.py",
   "start": 18,
   "end": 18
- },
- {
-  "leaf": "calculate_frechet_distance",
-  "qual": "calculate_frechet_distance",
-  "subpkg": "metrics",
-  "file": "combra/metrics/fid.py",
-  "start": 18,
-  "end": 18
  }
 ]

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -65,13 +65,13 @@ Re-exported from [torch-fidelity](https://github.com/toshas/torch-fidelity) — 
 ```
 ````
 
-For lower-level control, `combra.metrics` also re-exports the two underlying [pytorch-fid](https://github.com/mseitzer/pytorch-fid) primitives — `compute_fid` is just a thin convenience wrapper around the first.
+For lower-level control, `combra.metrics` also re-exports the underlying [pytorch-fid](https://github.com/mseitzer/pytorch-fid) folder-level primitive — `compute_fid` is just a thin convenience wrapper around it. FID is always computed from images; combra does not expose the raw mean/covariance (`mu`/`sigma`) form of the Fréchet distance.
 
 ````{py:function} combra.metrics.calculate_fid_given_paths(paths, batch_size, device, dims, num_workers=1) -> float
 
-Re-exported from [pytorch-fid](https://github.com/mseitzer/pytorch-fid). Computes FID between the two folders in `paths` — the function `compute_fid` wraps with sensible defaults and automatic device selection.
+Re-exported from [pytorch-fid](https://github.com/mseitzer/pytorch-fid). Computes FID between the two image folders in `paths` — the function `compute_fid` wraps it with sensible defaults and automatic device selection.
 
-:param paths: Two folder paths `[real, generated]`.
+:param paths: Two image-folder paths `[real, generated]`.
 :type paths: list[str]
 :param batch_size: Forward-pass batch size.
 :type batch_size: int
@@ -82,24 +82,6 @@ Re-exported from [pytorch-fid](https://github.com/mseitzer/pytorch-fid). Compute
 :param num_workers: Dataloader workers. Default: `1`.
 :type num_workers: int, optional
 :returns: **fid** (*float*) – The Fréchet distance.
-:rtype: float
-````
-
-````{py:function} combra.metrics.calculate_frechet_distance(mu1, sigma1, mu2, sigma2, eps=1e-6) -> float
-
-Re-exported from [pytorch-fid](https://github.com/mseitzer/pytorch-fid). The FID formula itself — the Fréchet distance between two multivariate Gaussians described by their activation mean/covariance. Use it when you already hold the InceptionV3 statistics.
-
-:param mu1: Mean activation vector of the first set.
-:type mu1: ndarray
-:param sigma1: Covariance matrix of the first set.
-:type sigma1: ndarray
-:param mu2: Mean activation vector of the second set.
-:type mu2: ndarray
-:param sigma2: Covariance matrix of the second set.
-:type sigma2: ndarray
-:param eps: Diagonal nudge keeping the matrix square root finite when the covariance product is singular. Default: `1e-6`.
-:type eps: float, optional
-:returns: **fid** (*float*) – The Fréchet (FID) distance.
 :rtype: float
 ````
 


### PR DESCRIPTION
## Summary

Adds Claude tooling to the repo and brings the combra API docs back in sync with the current library.

### 1. Karpathy guidelines skill + CLAUDE.md
- New `CLAUDE.md` — a short wc_cv project preamble (what the repo is, how to build the docs, where combra's tests live) followed by the [Karpathy coding guidelines](https://github.com/multica-ai/andrej-karpathy-skills) verbatim.
- New `.claude/skills/karpathy-guidelines/SKILL.md` — the skill at the path Claude Code auto-discovers as a project skill.

### 2. Metrics & tests docs synced to current combra
- `docs/api/metrics.md`
  - Documented the new `pre_endpoints_by_kind` param on `convergence_stats` / `print_convergence_report`, the new output columns (`alpha`, `pre_alpha`, `pre_rel_err_abs_%`, `b_hat`, `fit_r2`; renamed `m_at_nmax` → `m_at_nhi`), and rewrote the stale "T3 (asymptote)" table description to the current **T3 (gains+alpha)** table.
  - **FID is now documented as image-only** — removed the stats-based `calculate_frechet_distance(mu, sigma, …)` directive (and its source-link record in `docs/_static/source_index.json`). FID is exposed only through its image-folder entry points.
- `docs/api/tests.md` — `test_fractal_dimensions` now documents all **7 reference shapes** (point, line, filled square, Cantor dust, Sierpiński carpet/triangle, Koch curve) and the average-relative-error summary, instead of the old 3 fractals.

### 3. Install + test info in Getting Started
- `docs/get_started.md` — install-from-source steps, an optional-extras table (`tests`/`docs`/`dev`), and a new **Testing** section (pytest + ruff, the 3.10/3.11/3.12 CI matrix, and the in-package `tests.test_fractal_dimensions` sanity check).

### Verification
- Doc claims checked against the combra source (`convergence.py` columns, `pyproject.toml` extras, `tests/fractal.py` shape list).
- `python -m sphinx -b html docs public` builds with no warnings.

> Companion library change in `dkagramanyan/combra` (same branch) drops the stats-based `calculate_frechet_distance` from the public FID API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Fy3cCr3ETbgYA6YoFERzq)_