### PR TITLE
Refactor FID and add Gaussian-fit metrics to training module

### DIFF
--- a/docs/_static/source_index.json
+++ b/docs/_static/source_index.json
@@ -373,31 +373,31 @@
   "subpkg": "metrics",
   "file": "combra/metrics/compare.py",
   "start": 56,
-  "end": 75
+  "end": 76
  },
  {
   "leaf": "compare_folders",
   "qual": "compare_folders",
   "subpkg": "metrics",
   "file": "combra/metrics/compare.py",
-  "start": 78,
-  "end": 186
+  "start": 79,
+  "end": 187
  },
  {
   "leaf": "compare_pairs",
   "qual": "compare_pairs",
   "subpkg": "metrics",
   "file": "combra/metrics/compare.py",
-  "start": 189,
-  "end": 255
+  "start": 190,
+  "end": 256
  },
  {
   "leaf": "metrics_vs_n",
   "qual": "metrics_vs_n",
   "subpkg": "metrics",
   "file": "combra/metrics/compare.py",
-  "start": 258,
-  "end": 315
+  "start": 259,
+  "end": 316
  },
  {
   "leaf": "_save_png",
@@ -1428,136 +1428,144 @@
   "qual": "_cached",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 56,
-  "end": 67
+  "start": 60,
+  "end": 71
  },
  {
   "leaf": "_kw_key",
   "qual": "_kw_key",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 70,
-  "end": 71
+  "start": 74,
+  "end": 75
  },
  {
   "leaf": "_as_numpy_batch",
   "qual": "_as_numpy_batch",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 74,
-  "end": 88
+  "start": 78,
+  "end": 92
  },
  {
   "leaf": "images_to_angle_density",
   "qual": "images_to_angle_density",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 91,
-  "end": 109
+  "start": 95,
+  "end": 113
  },
  {
   "leaf": "_as_density",
   "qual": "_as_density",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 112,
-  "end": 124
+  "start": 116,
+  "end": 128
  },
  {
   "leaf": "compute_wasserstein_metrics",
   "qual": "compute_wasserstein_metrics",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 127,
-  "end": 139
+  "start": 131,
+  "end": 143
+ },
+ {
+  "leaf": "compute_gauss_metrics",
+  "qual": "compute_gauss_metrics",
+  "subpkg": "metrics",
+  "file": "combra/metrics/training.py",
+  "start": 146,
+  "end": 159
  },
  {
   "leaf": "_to_uint8_rgb",
   "qual": "_to_uint8_rgb",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 145,
-  "end": 165
+  "start": 165,
+  "end": 185
  },
  {
   "leaf": "_resolve_device",
   "qual": "_resolve_device",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 168,
-  "end": 173
+  "start": 188,
+  "end": 193
  },
  {
   "leaf": "_load_clip",
   "qual": "_load_clip",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 177,
-  "end": 181
+  "start": 197,
+  "end": 201
  },
  {
   "leaf": "_load_dinov2",
   "qual": "_load_dinov2",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 185,
-  "end": 188
+  "start": 205,
+  "end": 208
  },
  {
   "leaf": "_load_inception",
   "qual": "_load_inception",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 192,
-  "end": 196
+  "start": 212,
+  "end": 216
  },
  {
   "leaf": "compute_cmmd",
   "qual": "compute_cmmd",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 199,
-  "end": 252
+  "start": 219,
+  "end": 272
  },
  {
   "leaf": "_mu_sigma",
   "qual": "_mu_sigma",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 255,
-  "end": 256
+  "start": 275,
+  "end": 276
  },
  {
   "leaf": "_require_image_set",
   "qual": "_require_image_set",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 259,
-  "end": 269
+  "start": 279,
+  "end": 289
  },
  {
   "leaf": "compute_fd_dinov2",
   "qual": "compute_fd_dinov2",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 272,
-  "end": 324
+  "start": 292,
+  "end": 344
  },
  {
   "leaf": "compute_fid",
   "qual": "compute_fid",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 327,
-  "end": 363
+  "start": 347,
+  "end": 383
  },
  {
   "leaf": "compute_all_metrics",
   "qual": "compute_all_metrics",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 369,
-  "end": 429
+  "start": 389,
+  "end": 451
  },
  {
   "leaf": "_resample_to_grid",
@@ -1574,5 +1582,21 @@
   "file": "combra/metrics/wasserstein.py",
   "start": 42,
   "end": 68
+ },
+ {
+  "leaf": "gauss_relative_errors",
+  "qual": "gauss_relative_errors",
+  "subpkg": "metrics",
+  "file": "combra/metrics/gauss.py",
+  "start": 19,
+  "end": 43
+ },
+ {
+  "leaf": "gauss_density_metrics",
+  "qual": "gauss_density_metrics",
+  "subpkg": "metrics",
+  "file": "combra/metrics/gauss.py",
+  "start": 46,
+  "end": 61
  }
 ]

--- a/docs/_static/source_index.json
+++ b/docs/_static/source_index.json
@@ -340,64 +340,64 @@
   "qual": "load_rows",
   "subpkg": "metrics",
   "file": "combra/metrics/compare.py",
-  "start": 8,
-  "end": 22
+  "start": 9,
+  "end": 23
  },
  {
   "leaf": "index_by_name_step",
   "qual": "index_by_name_step",
   "subpkg": "metrics",
   "file": "combra/metrics/compare.py",
-  "start": 25,
-  "end": 26
+  "start": 26,
+  "end": 27
  },
  {
   "leaf": "find_ethalon",
   "qual": "find_ethalon",
   "subpkg": "metrics",
   "file": "combra/metrics/compare.py",
-  "start": 29,
-  "end": 38
+  "start": 30,
+  "end": 39
  },
  {
   "leaf": "parquet_has_step",
   "qual": "parquet_has_step",
   "subpkg": "metrics",
   "file": "combra/metrics/compare.py",
-  "start": 41,
-  "end": 52
+  "start": 42,
+  "end": 53
  },
  {
   "leaf": "compute_metrics",
   "qual": "compute_metrics",
   "subpkg": "metrics",
   "file": "combra/metrics/compare.py",
-  "start": 55,
-  "end": 87
+  "start": 56,
+  "end": 75
  },
  {
   "leaf": "compare_folders",
   "qual": "compare_folders",
   "subpkg": "metrics",
   "file": "combra/metrics/compare.py",
-  "start": 90,
-  "end": 198
+  "start": 78,
+  "end": 186
  },
  {
   "leaf": "compare_pairs",
   "qual": "compare_pairs",
   "subpkg": "metrics",
   "file": "combra/metrics/compare.py",
-  "start": 201,
-  "end": 267
+  "start": 189,
+  "end": 255
  },
  {
   "leaf": "metrics_vs_n",
   "qual": "metrics_vs_n",
   "subpkg": "metrics",
   "file": "combra/metrics/compare.py",
-  "start": 270,
-  "end": 327
+  "start": 258,
+  "end": 315
  },
  {
   "leaf": "_save_png",
@@ -438,14 +438,6 @@
   "file": "combra/metrics/plot.py",
   "start": 244,
   "end": 358
- },
- {
-  "leaf": "compute_fid",
-  "qual": "compute_fid",
-  "subpkg": "metrics",
-  "file": "combra/metrics/fid.py",
-  "start": 16,
-  "end": 37
  },
  {
   "leaf": "imdivide",
@@ -640,12 +632,28 @@
   "end": 173
  },
  {
+  "leaf": "_disk_offsets",
+  "qual": "_disk_offsets",
+  "subpkg": "image",
+  "file": "combra/image/utils.py",
+  "start": 8,
+  "end": 14
+ },
+ {
+  "leaf": "_median_disk_u8",
+  "qual": "_median_disk_u8",
+  "subpkg": "image",
+  "file": "combra/image/utils.py",
+  "start": 18,
+  "end": 39
+ },
+ {
   "leaf": "_bin_grad_u8",
   "qual": "_bin_grad_u8",
   "subpkg": "image",
   "file": "combra/image/utils.py",
-  "start": 6,
-  "end": 14
+  "start": 43,
+  "end": 51
  },
  {
   "leaf": "_load_angles_parquet",
@@ -885,7 +893,7 @@
   "subpkg": "data",
   "file": "combra/data/pobedit_dataset.py",
   "start": 230,
-  "end": 953
+  "end": 965
  },
  {
   "leaf": "__init__",
@@ -965,71 +973,71 @@
   "subpkg": "data",
   "file": "combra/data/pobedit_dataset.py",
   "start": 479,
-  "end": 511
+  "end": 516
  },
  {
   "leaf": "_build_prep_cache_cpu",
   "qual": "PobeditDataset._build_prep_cache_cpu",
   "subpkg": "data",
   "file": "combra/data/pobedit_dataset.py",
-  "start": 513,
-  "end": 529
+  "start": 518,
+  "end": 534
  },
  {
   "leaf": "_class_meta",
   "qual": "PobeditDataset._class_meta",
   "subpkg": "data",
   "file": "combra/data/pobedit_dataset.py",
-  "start": 531,
-  "end": 545
+  "start": 536,
+  "end": 550
  },
  {
   "leaf": "_parquet_path",
   "qual": "PobeditDataset._parquet_path",
   "subpkg": "data",
   "file": "combra/data/pobedit_dataset.py",
-  "start": 548,
-  "end": 553
+  "start": 553,
+  "end": 558
  },
  {
   "leaf": "_begin_generate",
   "qual": "PobeditDataset._begin_generate",
   "subpkg": "data",
   "file": "combra/data/pobedit_dataset.py",
-  "start": 555,
-  "end": 569
+  "start": 560,
+  "end": 576
  },
  {
   "leaf": "_write_class_row",
   "qual": "PobeditDataset._write_class_row",
   "subpkg": "data",
   "file": "combra/data/pobedit_dataset.py",
-  "start": 572,
-  "end": 590
+  "start": 579,
+  "end": 597
  },
  {
   "leaf": "generate_angles",
   "qual": "PobeditDataset.generate_angles",
   "subpkg": "data",
   "file": "combra/data/pobedit_dataset.py",
-  "start": 592,
-  "end": 793
+  "start": 599,
+  "end": 805
  },
  {
   "leaf": "generate_beams",
   "qual": "PobeditDataset.generate_beams",
   "subpkg": "data",
   "file": "combra/data/pobedit_dataset.py",
-  "start": 795,
-  "end": 953
+  "start": 807,
+  "end": 965
  },
  {
   "leaf": "generate_angles_sweep",
   "qual": "generate_angles_sweep",
   "subpkg": "data",
   "file": "combra/data/pobedit_dataset.py",
-  "start": 956,
-  "end": 991
+  "start": 968,
+  "end": 1003
  },
  {
   "leaf": "_parse_kimg",
@@ -1416,75 +1424,155 @@
   "end": 111
  },
  {
+  "leaf": "_cached",
+  "qual": "_cached",
+  "subpkg": "metrics",
+  "file": "combra/metrics/training.py",
+  "start": 56,
+  "end": 67
+ },
+ {
+  "leaf": "_kw_key",
+  "qual": "_kw_key",
+  "subpkg": "metrics",
+  "file": "combra/metrics/training.py",
+  "start": 70,
+  "end": 71
+ },
+ {
+  "leaf": "_as_numpy_batch",
+  "qual": "_as_numpy_batch",
+  "subpkg": "metrics",
+  "file": "combra/metrics/training.py",
+  "start": 74,
+  "end": 88
+ },
+ {
   "leaf": "images_to_angle_density",
   "qual": "images_to_angle_density",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 84,
-  "end": 102
+  "start": 91,
+  "end": 109
  },
  {
-  "leaf": "compute_w1",
-  "qual": "compute_w1",
+  "leaf": "_as_density",
+  "qual": "_as_density",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 115,
-  "end": 119
+  "start": 112,
+  "end": 124
  },
  {
-  "leaf": "compute_w2",
-  "qual": "compute_w2",
+  "leaf": "compute_wasserstein_metrics",
+  "qual": "compute_wasserstein_metrics",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 122,
-  "end": 126
+  "start": 127,
+  "end": 139
  },
  {
-  "leaf": "compute_circular_w1",
-  "qual": "compute_circular_w1",
+  "leaf": "_to_uint8_rgb",
+  "qual": "_to_uint8_rgb",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 129,
-  "end": 135
+  "start": 145,
+  "end": 165
  },
  {
-  "leaf": "compute_circular_w2",
-  "qual": "compute_circular_w2",
+  "leaf": "_resolve_device",
+  "qual": "_resolve_device",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 138,
-  "end": 144
+  "start": 168,
+  "end": 173
+ },
+ {
+  "leaf": "_load_clip",
+  "qual": "_load_clip",
+  "subpkg": "metrics",
+  "file": "combra/metrics/training.py",
+  "start": 177,
+  "end": 181
+ },
+ {
+  "leaf": "_load_dinov2",
+  "qual": "_load_dinov2",
+  "subpkg": "metrics",
+  "file": "combra/metrics/training.py",
+  "start": 185,
+  "end": 188
+ },
+ {
+  "leaf": "_load_inception",
+  "qual": "_load_inception",
+  "subpkg": "metrics",
+  "file": "combra/metrics/training.py",
+  "start": 192,
+  "end": 196
  },
  {
   "leaf": "compute_cmmd",
   "qual": "compute_cmmd",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 204,
-  "end": 257
+  "start": 199,
+  "end": 252
+ },
+ {
+  "leaf": "_mu_sigma",
+  "qual": "_mu_sigma",
+  "subpkg": "metrics",
+  "file": "combra/metrics/training.py",
+  "start": 255,
+  "end": 256
+ },
+ {
+  "leaf": "_require_image_set",
+  "qual": "_require_image_set",
+  "subpkg": "metrics",
+  "file": "combra/metrics/training.py",
+  "start": 259,
+  "end": 269
  },
  {
   "leaf": "compute_fd_dinov2",
   "qual": "compute_fd_dinov2",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 264,
-  "end": 315
+  "start": 272,
+  "end": 324
+ },
+ {
+  "leaf": "compute_fid",
+  "qual": "compute_fid",
+  "subpkg": "metrics",
+  "file": "combra/metrics/training.py",
+  "start": 327,
+  "end": 363
  },
  {
   "leaf": "compute_all_metrics",
   "qual": "compute_all_metrics",
   "subpkg": "metrics",
   "file": "combra/metrics/training.py",
-  "start": 354,
-  "end": 411
+  "start": 369,
+  "end": 429
+ },
+ {
+  "leaf": "_resample_to_grid",
+  "qual": "_resample_to_grid",
+  "subpkg": "metrics",
+  "file": "combra/metrics/wasserstein.py",
+  "start": 19,
+  "end": 39
  },
  {
   "leaf": "wasserstein_density_metrics",
   "qual": "wasserstein_density_metrics",
   "subpkg": "metrics",
   "file": "combra/metrics/wasserstein.py",
-  "start": 46,
-  "end": 74
+  "start": 42,
+  "end": 68
  }
 ]

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -2,7 +2,7 @@
 
 The `combra.metrics` module bundles three families of metrics:
 
-- **Training-loop / batch metrics** — score generated images on the fly (no parquet round-trip): classic InceptionV3 FID (`compute_fid`), CLIP-MMD (`compute_cmmd`), Fréchet distance on DINOv2 features (`compute_fd_dinov2`), and the four angle-Wasserstein distances between two samples' angle densities (`compute_wasserstein_metrics`). Every metric takes **in-memory images** (a numpy array or torch tensor), not a folder of files. Each side may be a **single image or a batch** (Wasserstein and CMMD are valid on one image; the Fréchet-distance metrics FID/FD-DINOv2 need ≥ 2). `compute_all_metrics` runs the whole set — FID included — in one call. Every two-input metric takes the *reference* first, then the *generated*.
+- **Training-loop / batch metrics** — score generated images on the fly (no parquet round-trip): classic InceptionV3 FID (`compute_fid`), CLIP-MMD (`compute_cmmd`), Fréchet distance on DINOv2 features (`compute_fd_dinov2`), the four angle-Wasserstein distances between two samples' angle densities (`compute_wasserstein_metrics`), and the bimodal-Gaussian fit relative errors (`compute_gauss_metrics`). Every metric takes **in-memory images** (a numpy array or torch tensor), not a folder of files. Each side may be a **single image or a batch** (Wasserstein, Gaussian and CMMD are valid on one image; the Fréchet-distance metrics FID/FD-DINOv2 need ≥ 2). `compute_all_metrics` runs the whole set — FID included — in one call. Every two-input metric takes the *reference* first, then the *generated*.
 - **Distribution comparison helpers** — for comparing per-class angle distributions stored as parquet files.
 - **Convergence analysis** — N-sweep aggregation, Kendall trend tests, plateau fits, and the convergence-grid / gain-distribution plots used by `3_metrics_convergence.ipynb`.
 
@@ -20,16 +20,17 @@ writing them to disk. They live in `combra.metrics.training`.
 (`(H, W)`) and a **batch** (`(N, H, W)`, `(N, C, H, W)`, or `(N, H, W, C)`), but
 they differ in what a single image *means*:
 
-- `compute_wasserstein_metrics` and `compute_cmmd` are valid on a **single
-  image** — Wasserstein reduces each side to an angle density, and CMMD uses
-  kernel means, neither of which needs a sample of images.
+- `compute_wasserstein_metrics`, `compute_gauss_metrics` and `compute_cmmd` are
+  valid on a **single image** — the angle metrics reduce each side to an angle
+  density (then, for the Gaussian metrics, fit it), and CMMD uses kernel means,
+  none of which needs a sample of images.
 - The **Fréchet-distance** metrics — `compute_fd_dinov2` and the InceptionV3 FID
   (`compute_fid`, also computed inside `compute_all_metrics`) — estimate a
   per-side **covariance**, which is undefined for one image, so they require
   **≥ 2 images per side** and raise `ValueError` otherwise (inside
   `compute_all_metrics` this surfaces as a `nan` for that metric).
-- `compute_wasserstein_metrics` additionally accepts a precomputed `(x, y)`
-  angle density in place of images on either side.
+- `compute_wasserstein_metrics` and `compute_gauss_metrics` additionally accept a
+  precomputed `(x, y)` angle density in place of images on either side.
 
 The backbone models (CLIP / DINOv2 / InceptionV3) are loaded once per process and
 memoised with `functools.cache`. Each two-input metric also takes an optional
@@ -192,11 +193,52 @@ Reduce a batch of images to a single angle density `(x, y)`. Runs `_preprocess_i
 :rtype: tuple(ndarray, ndarray)
 ````
 
+### Gaussian-fit metrics
+
+`compute_gauss_metrics` mirrors `compute_wasserstein_metrics`, but instead of a
+transport distance it fits a **bimodal Gaussian** to each side's angle density
+({py:func}`combra.approx.bimodal_gauss_approx` — two modes, each with a mean `mu`,
+width `sigma` and amplitude `amp`) and reports the **per-mode relative error**
+`(generated − reference) / reference` of every fitted parameter. These are the
+same six numbers (`mu1`, `mu2`, `sigma1`, `sigma2`, `amp1`, `amp2`) the parquet
+comparison path computes from its stored fits, made available directly from
+in-memory images.
+
+````{py:function} combra.metrics.compute_gauss_metrics(reference, generated, step=None, reference_cache=None, **angle_kw) -> dict
+
+Bimodal-Gaussian relative-error metrics between a reference and a generated sample, returned as a flat dict `{'mu1', 'mu2', 'sigma1', 'sigma2', 'amp1', 'amp2'}` — mode 1 then mode 2 for each fitted parameter. Each side is reduced to its angle density once and fitted with {py:func}`combra.approx.bimodal_gauss_approx`; each value is `(generated − reference) / reference` for that parameter.
+
+`reference` and `generated` may each be **a single `(H, W)` image**, **a batch of images**, or **a precomputed `(x, y)` angle density** (a length-2 pair of 1-D arrays) — image input is reduced to a density, a density is used as-is. The `reference_cache` is keyed the same way as `compute_wasserstein_metrics`, so a cache shared between the two reuses the one reference angle density.
+
+:param reference: Reference sample — image, image batch, or `(x, y)` density.
+:type reference: ndarray or torch.Tensor or tuple
+:param generated: Generated sample to score — image, image batch, or `(x, y)` density.
+:type generated: ndarray or torch.Tensor or tuple
+:param step: Histogram bin width in degrees (image input only). Defaults to `5.0`. Default: `None`.
+:type step: float or None, optional
+:param reference_cache: Opt-in dict memoising the reference angle density across calls. Default: `None`.
+:type reference_cache: dict or None, optional
+:param angle_kw: Extra keyword args forwarded to `images_to_angle_density` (`border_eps`, `tol`, `min_segment_len`).
+:returns: **metrics** (*dict*) – Keys `mu1`, `mu2`, `sigma1`, `sigma2`, `amp1`, `amp2` — the per-mode relative errors of the fitted means, widths and amplitudes.
+:rtype: dict
+
+**Example**
+
+```python
+>>> from combra.metrics import compute_gauss_metrics
+>>> errs = compute_gauss_metrics(real_batch, generated_batch)   # batches
+>>> one  = compute_gauss_metrics(real_image, generated_image)   # single images
+>>> errs['mu1'], errs['sigma2']
+```
+
+The density-level core (used by the parquet comparison path) lives at `combra.metrics.gauss.gauss_density_metrics`; the raw per-mode error math, shared with `compute_metrics`, is `combra.metrics.gauss.gauss_relative_errors`.
+````
+
 ### Unified entry point
 
 ````{py:function} combra.metrics.compute_all_metrics(reference_images, generated_images, *, step=None, device=None, angle_kw=None, reference_cache=None) -> dict
 
-Run every batch metric for a (reference, generated) pair in parallel and return one flat dict. The angle-Wasserstein metrics (`w1`, `w2`, `circular_w1`, `circular_w2`) compare the two samples' angle densities; `fid` (classic InceptionV3 FID on the in-memory images), `cmmd`, and `fd_dinov2` compare their deep features. An image-feature metric that cannot run (missing optional dependency, no network, **or fewer than 2 images per side** for the Fréchet-distance `fid`/`fd_dinov2`) is recorded as `nan` and logged, so the angle metrics still come back. A single image therefore yields real `w*`/`cmmd` values and `nan` for `fid`/`fd_dinov2`.
+Run every batch metric for a (reference, generated) pair in parallel and return one flat dict. The angle-density metrics — the Wasserstein distances (`w1`, `w2`, `circular_w1`, `circular_w2`) and the bimodal-Gaussian relative errors (`mu1`, `mu2`, `sigma1`, `sigma2`, `amp1`, `amp2`) — compare the two samples' angle densities; `fid` (classic InceptionV3 FID on the in-memory images), `cmmd`, and `fd_dinov2` compare their deep features. An image-feature metric that cannot run (missing optional dependency, no network, **or fewer than 2 images per side** for the Fréchet-distance `fid`/`fd_dinov2`) is recorded as `nan` and logged, so the angle metrics still come back. A single image therefore yields real `w*`/`mu*`/`sigma*`/`amp*`/`cmmd` values and `nan` for `fid`/`fd_dinov2`.
 
 :param reference_images: Batch of reference (real) images.
 :type reference_images: ndarray or torch.Tensor
@@ -210,7 +252,7 @@ Run every batch metric for a (reference, generated) pair in parallel and return 
 :type angle_kw: dict or None, optional
 :param reference_cache: Opt-in dict reused across calls to compute the reference-side features once. Default: `None`.
 :type reference_cache: dict or None, optional
-:returns: **results** (*dict*) – Flat `{metric_name: value}` dict with keys `w1`, `w2`, `circular_w1`, `circular_w2`, `fid`, `cmmd`, `fd_dinov2`.
+:returns: **results** (*dict*) – Flat `{metric_name: value}` dict with keys `w1`, `w2`, `circular_w1`, `circular_w2`, `mu1`, `mu2`, `sigma1`, `sigma2`, `amp1`, `amp2`, `fid`, `cmmd`, `fd_dinov2`.
 :rtype: dict
 
 **Example**
@@ -218,7 +260,7 @@ Run every batch metric for a (reference, generated) pair in parallel and return 
 ```python
 >>> from combra.metrics import compute_all_metrics
 >>> scores = compute_all_metrics(real_batch, generated_batch)
->>> scores['cmmd'], scores['w1']
+>>> scores['cmmd'], scores['w1'], scores['mu1']
 ```
 ````
 

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -2,7 +2,7 @@
 
 The `combra.metrics` module bundles three families of metrics:
 
-- **Training-loop / batch metrics** — score generated images on the fly (no parquet round-trip): classic InceptionV3 FID, CLIP-MMD (`compute_cmmd`), Fréchet distance on DINOv2 features (`compute_fd_dinov2`), and the four angle-Wasserstein distances between two samples' angle densities (`compute_wasserstein_metrics`). Each side may be a **single image or a batch** (Wasserstein and CMMD are valid on one image; the Fréchet-distance metrics FID/FD-DINOv2 need ≥ 2). `compute_all_metrics` runs the whole set — FID included — in one call. Every two-input metric takes the *reference* first, then the *generated*. The folder-vs-folder FID convenience wrapper `compute_fid` lives here too.
+- **Training-loop / batch metrics** — score generated images on the fly (no parquet round-trip): classic InceptionV3 FID (`compute_fid`), CLIP-MMD (`compute_cmmd`), Fréchet distance on DINOv2 features (`compute_fd_dinov2`), and the four angle-Wasserstein distances between two samples' angle densities (`compute_wasserstein_metrics`). Every metric takes **in-memory images** (a numpy array or torch tensor), not a folder of files. Each side may be a **single image or a batch** (Wasserstein and CMMD are valid on one image; the Fréchet-distance metrics FID/FD-DINOv2 need ≥ 2). `compute_all_metrics` runs the whole set — FID included — in one call. Every two-input metric takes the *reference* first, then the *generated*.
 - **Distribution comparison helpers** — for comparing per-class angle distributions stored as parquet files.
 - **Convergence analysis** — N-sweep aggregation, Kendall trend tests, plateau fits, and the convergence-grid / gain-distribution plots used by `3_metrics_convergence.ipynb`.
 
@@ -24,10 +24,10 @@ they differ in what a single image *means*:
   image** — Wasserstein reduces each side to an angle density, and CMMD uses
   kernel means, neither of which needs a sample of images.
 - The **Fréchet-distance** metrics — `compute_fd_dinov2` and the InceptionV3 FID
-  inside `compute_all_metrics` — estimate a per-side **covariance**, which is
-  undefined for one image, so they require **≥ 2 images per side** and raise
-  `ValueError` otherwise (inside `compute_all_metrics` this surfaces as a `nan`
-  for that metric).
+  (`compute_fid`, also computed inside `compute_all_metrics`) — estimate a
+  per-side **covariance**, which is undefined for one image, so they require
+  **≥ 2 images per side** and raise `ValueError` otherwise (inside
+  `compute_all_metrics` this surfaces as a `nan` for that metric).
 - `compute_wasserstein_metrics` additionally accepts a precomputed `(x, y)`
   angle density in place of images on either side.
 
@@ -38,45 +38,41 @@ reference batch and the reference-side work (CLIP embedding, DINOv2 / Inception
 `(mu, sigma)`, angle density) runs only once. The cache is keyed by metric and
 parameters, **not** by the reference content — use one cache per reference batch.
 
-```python
-from combra import metrics
-```
-
 ### Image-feature metrics
 
 These compare the deep-feature distributions of a *reference* and a *generated*
-image set: classic InceptionV3 **FID**, CLIP-MMD (`compute_cmmd`), and the
-Fréchet distance on DINOv2 features (`compute_fd_dinov2`). FID is just one of
-these feature metrics — `compute_all_metrics` computes it in-memory alongside the
-others, and `compute_fid` is the standalone folder-vs-folder convenience wrapper.
+image set: classic InceptionV3 **FID** (`compute_fid`), CLIP-MMD (`compute_cmmd`),
+and the Fréchet distance on DINOv2 features (`compute_fd_dinov2`). FID is just one
+of these feature metrics — `compute_fid` scores two in-memory image batches, and
+`compute_all_metrics` computes the same FID alongside the others.
 `compute_cmmd` and `compute_fd_dinov2` need the `gen-metrics` extra
 (`pip install ".[gen-metrics]"`); the DINOv2 backbone is fetched from `torch.hub`
 on first use.
 
-````{py:function} combra.metrics.compute_fid(reference_folder, generated_folder, batch_size=50, dims=2048, device=None, num_workers=1) -> float
+````{py:function} combra.metrics.compute_fid(reference_images, generated_images, device=None, batch_size=50, dims=2048, reference_cache=None) -> float
 
-Classic folder-vs-folder FID, computed with [pytorch-fid](https://github.com/mseitzer/pytorch-fid) (a core dependency, so no `gen-metrics` extra needed). Walks both folders, runs every image through InceptionV3, and returns the Fréchet distance between the two activation distributions. The weights are downloaded and cached by pytorch-fid on first use. For the in-memory batch form of the same metric, use `compute_all_metrics`, whose result includes a `fid` key. Runs on PyTorch, selecting CUDA automatically when available.
+Classic InceptionV3 FID between two **in-memory image batches** (a numpy array or torch tensor), computed with [pytorch-fid](https://github.com/mseitzer/pytorch-fid) (a core dependency, so no `gen-metrics` extra needed). Runs every image through InceptionV3 and returns the Fréchet distance between the two activation distributions. Like every Fréchet-distance metric it estimates a per-side covariance, so it needs **≥ 2 images per side** and raises `ValueError` otherwise. The weights are downloaded and cached by pytorch-fid on first use. `compute_all_metrics` computes this same metric under its `fid` key. Runs on PyTorch, selecting CUDA automatically when available.
 
-:param reference_folder: Path to the reference (real) image folder.
-:type reference_folder: str or Path
-:param generated_folder: Path to the generated image folder.
-:type generated_folder: str or Path
+:param reference_images: Batch of reference (real) images.
+:type reference_images: ndarray or torch.Tensor
+:param generated_images: Batch of generated images.
+:type generated_images: ndarray or torch.Tensor
+:param device: Torch device to run on (e.g. `'cuda'` or `'cpu'`). When `None`, picks `'cuda'` if available, otherwise `'cpu'`. Default: `None`.
+:type device: str or torch.device or None, optional
 :param batch_size: Forward-pass batch size. Default: `50`.
 :type batch_size: int, optional
 :param dims: Dimensionality of the InceptionV3 feature layer (`64`, `192`, `768`, or `2048`). Default: `2048`.
 :type dims: int, optional
-:param device: Torch device to run on (e.g. `'cuda'` or `'cpu'`). When `None`, picks `'cuda'` if available, otherwise `'cpu'`. Default: `None`.
-:type device: str or torch.device or None, optional
-:param num_workers: Number of dataloader workers. Default: `1`.
-:type num_workers: int, optional
-:returns: **fid** (*float*) – The Fréchet (FID) distance. `0.0` when both folders are identical.
+:param reference_cache: Opt-in dict memoising the reference `(mu, sigma)` across calls. Default: `None`.
+:type reference_cache: dict or None, optional
+:returns: **fid** (*float*) – The Fréchet (FID) distance. `0.0` when both batches are identical.
 :rtype: float
 
 **Example**
 
 ```python
 >>> from combra.metrics import compute_fid
->>> fid = compute_fid('data/real', 'data/gen')  # CUDA when available, else CPU
+>>> fid = compute_fid(real_batch, generated_batch)  # CUDA when available, else CPU
 >>> print(f'FID = {fid:.4f}')
 ```
 

--- a/docs/examples/fid.md
+++ b/docs/examples/fid.md
@@ -3,12 +3,20 @@
 Compute FID between generated diffusion images and real images for several resolutions.
 See {py:func}`combra.metrics.compute_fid`.
 
-combra does not implement FID itself — `combra.metrics.fid` delegates to the reference library [pytorch-fid](https://github.com/mseitzer/pytorch-fid). It ships as a core dependency and downloads/caches its own InceptionV3 weights on first use, so there is no manual model setup. `compute_fid` runs on CUDA when it is available and falls back to CPU otherwise.
+combra does not implement FID itself — `compute_fid` delegates to the reference library [pytorch-fid](https://github.com/mseitzer/pytorch-fid). It ships as a core dependency and downloads/caches its own InceptionV3 weights on first use, so there is no manual model setup. `compute_fid` takes **in-memory image batches** (a numpy array or torch tensor), not a folder, and runs on CUDA when it is available, falling back to CPU otherwise.
 
-A multi-resolution sweep is just a loop over folder pairs:
+Load each resolution's images into a batch array, then loop over the pairs:
 
 ```python
+>>> import numpy as np
+>>> from PIL import Image
+>>> from pathlib import Path
 >>> from combra.metrics import compute_fid
+>>>
+>>> def load_batch(folder):
+...     return np.stack([np.asarray(Image.open(p).convert('RGB'))
+...                      for p in sorted(Path(folder).glob('*.png'))])
+>>>
 >>> BASE = 'data/separeted'
 >>> pairs = [
 ...     ('256x256', f'{BASE}/o_bc_left_4x_768_256x256_N360', f'{BASE}/gen_diff_256x256_N500'),
@@ -17,7 +25,7 @@ A multi-resolution sweep is just a loop over folder pairs:
 ... ]
 >>> results = {}
 >>> for name, real, gen in pairs:
-...     fid = compute_fid(real, gen, batch_size=50)
+...     fid = compute_fid(load_batch(real), load_batch(gen), batch_size=50)
 ...     results[name] = fid
 ...     print(f'{name}: FID = {fid:.4f}')
 ```

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -21,7 +21,7 @@ pip install .          # or:  pip install -e .   for an editable install
 | `gen-metrics` | `pip install ".[gen-metrics]"`   | `open-clip-torch` for `compute_cmmd` / `compute_fd_dinov2` |
 | `dev`         | `pip install -e ".[dev]"`        | the `tests` extra + ruff                      |
 
-FID metrics work out of the box. `combra.metrics.fid` delegates to [pytorch-fid](https://github.com/mseitzer/pytorch-fid), which ships as a core dependency and downloads/caches its own InceptionV3 weights on first use — no manual model setup. `compute_fid` runs on CUDA when available and falls back to CPU; see {doc}`combra.metrics <api/metrics>`.
+FID metrics work out of the box. `compute_fid` delegates to [pytorch-fid](https://github.com/mseitzer/pytorch-fid), which ships as a core dependency and downloads/caches its own InceptionV3 weights on first use — no manual model setup. It scores in-memory image batches and runs on CUDA when available, falling back to CPU; see {doc}`combra.metrics <api/metrics>`.
 
 The angle-Wasserstein training metrics use [POT](https://pythonot.github.io/) (`pot`), a core dependency. The CLIP-MMD and DINOv2 metrics (`compute_cmmd`, `compute_fd_dinov2`) additionally need the `gen-metrics` extra; the DINOv2 backbone is fetched from `torch.hub` on first use.
 


### PR DESCRIPTION
## Summary

Reorganizes the metrics module to consolidate training-loop metrics in `combra/metrics/training.py` and adds a new `compute_gauss_metrics` function for bimodal-Gaussian angle-density fitting. The `compute_fid` function is moved from `combra/metrics/fid.py` to `training.py` and refactored to accept in-memory image batches instead of folder paths, aligning with the batch-metric API pattern.

## Key Changes

- **Moved `compute_fid` to `training.py`**: Changed signature from `compute_fid(reference_folder, generated_folder, ...)` to `compute_fid(reference_images, generated_images, ...)` to accept numpy arrays or torch tensors instead of folder paths. Adds optional `reference_cache` parameter for memoization consistency with other batch metrics.

- **Added `compute_gauss_metrics`**: New function that fits a bimodal Gaussian to each side's angle density and returns per-mode relative errors (`mu1`, `mu2`, `sigma1`, `sigma2`, `amp1`, `amp2`). Mirrors `compute_wasserstein_metrics` API — accepts single images, batches, or precomputed `(x, y)` densities.

- **New helper functions in `training.py`**: 
  - `_cached`, `_kw_key`, `_as_numpy_batch` — internal utilities for caching and batch handling
  - `_as_density` — converts images to angle density
  - `_to_uint8_rgb`, `_resolve_device`, `_load_clip`, `_load_dinov2`, `_load_inception` — model loading and image conversion helpers
  - `_mu_sigma`, `_require_image_set` — Fréchet-distance metric support

- **New module `combra/metrics/gauss.py`**: Extracted density-level Gaussian fitting logic (`gauss_relative_errors`, `gauss_density_metrics`) for reuse by both batch and parquet comparison paths.

- **Updated `compute_all_metrics`**: Now includes Gaussian metrics (`mu1`, `mu2`, `sigma1`, `sigma2`, `amp1`, `amp2`) in its output dict alongside existing Wasserstein and feature metrics.

- **Updated `combra/image/utils.py`**: Added `_disk_offsets` and `_median_disk_u8` helper functions; shifted line numbers for existing `_bin_grad_u8`.

- **Updated `combra/data/pobedit_dataset.py`**: Line number shifts due to additions in upstream modules; no functional changes to the class itself.

- **Documentation updates**: 
  - `docs/api/metrics.md` — Updated function signatures, clarified that `compute_fid` now takes in-memory batches, documented `compute_gauss_metrics`, updated `compute_all_metrics` output keys
  - `docs/examples/fid.md` — Added example showing how to load image folders into numpy arrays before calling `compute_fid`
  - `docs/_static/source_index.json` — Regenerated to reflect new/moved functions and line numbers

## Implementation Details

- The refactored `compute_fid` maintains backward compatibility with pytorch-fid's InceptionV3 backend while adopting the batch-metric pattern (in-memory arrays, optional caching).
- `compute_gauss_metrics` reuses the angle-density extraction pipeline from `compute_wasserstein_metrics`, ensuring consistent preprocessing.
- Helper functions are prefixed with `_` to indicate internal use; the public API remains `compute_fid`, `compute_gauss_metrics`, `compute_wasserstein_metrics`, `compute_cmmd`, `compute_fd_dinov2`, and `compute_all_metrics`.
- Cache keys are consistent across metrics, allowing a single `reference_cache` dict to be shared between `compute_wasserstein_metrics` and `compute_gauss_metrics`.

https://claude.ai/code/session_01JxArnpAkc5pG6hFGgU8MJU