### PR TITLE
Document DiffiT sampling options and training evaluation details

### DIFF
--- a/docs/examples/diffit.md
+++ b/docs/examples/diffit.md
@@ -38,15 +38,42 @@ diffit-train --outdir=./training-runs \
 ```
 
 During training, at each evaluation tick (every `--snap` ticks) the loop
-generates a batch from the EMA model and runs `compute_all_metrics(reals, fakes)`
-(when combra is installed). All returned metrics — angle-Wasserstein `w1`, `w2`,
-`circular_w1`, `circular_w2` and the image-feature metrics `fid`, `cmmd`,
-`fd_dinov2` — are logged to TensorBoard under `Metrics/combra_*`, written to
-`stats.jsonl`, and printed to the run log, alongside DiffiT's own IS / FID / sFID
-/ Precision / Recall. Metrics whose optional backends are unavailable (e.g. no
-network to fetch DINOv2 weights) are recorded as `nan`; the angle metrics always
-come back. The reference batch is scored once and cached, so only the
-generated-side work is repeated each tick.
+generates a batch of images from the EMA model by running the DPM-Solver++
+reverse-diffusion sampler in VAE latent space, decodes them to pixels, and runs
+`compute_all_metrics(reals, fakes)` (when combra is installed). All returned
+metrics — angle-Wasserstein `w1`, `w2`, `circular_w1`, `circular_w2`, the
+bimodal-Gaussian relative errors `mu1`/`mu2`/`sigma1`/`sigma2`/`amp1`/`amp2`, and
+the image-feature metrics `fid`, `cmmd`, `fd_dinov2` — are logged to TensorBoard
+under `Metrics/combra_*`, written to `stats.jsonl`, and printed to the run log,
+alongside DiffiT's own IS / FID / sFID / Precision / Recall. Metrics whose
+optional backends are unavailable (e.g. no network to fetch DINOv2 weights) are
+recorded as `nan`; the angle metrics always come back. The reference batch is
+scored once and cached, so only the generated-side work is repeated each tick.
+
+**Sample count.** When combra is **not** installed, the eval generates
+`--num-fid-samples` images (default 10000), unchanged. When combra **is**
+installed, each evaluation tick instead scores the **whole training dataset**:
+the reference is every real image used once, and DiffiT generates a matching
+number of images. This makes the combra metrics a full-dataset measurement rather
+than a 10k subsample. (Set `--num-fid-samples 0` to disable eval entirely.)
+
+To keep the larger per-tick generation affordable, the EMA model's sampling
+forward is `torch.compile`d, which speeds up the reverse-diffusion latent
+generation that dominates evaluation time.
+
+### Dry run
+
+To validate the config and data wiring without starting a real run, pass `-n` /
+`--dry-run` — it prints the resolved training options (resolution, batch, sample
+count, etc.) and exits before training:
+
+```bash
+diffit-train --outdir=./training-runs \
+    --cfg=diffit-256 \
+    --data=./datasets/imagenet_256x256.zip \
+    --gpus 1 --batch-gpu 4 \
+    -n
+```
 
 ## Evaluation
 

--- a/docs/examples/diffit.md
+++ b/docs/examples/diffit.md
@@ -38,8 +38,9 @@ diffit-train --outdir=./training-runs \
 ```
 
 During training, at each evaluation tick (every `--snap` ticks) the loop
-generates a batch of images from the EMA model by running the DPM-Solver++
-reverse-diffusion sampler in VAE latent space, decodes them to pixels, and runs
+generates a batch of images from the EMA model by running the configured
+reverse-diffusion sampler (DDIM by default — see the Samplers section below) in
+VAE latent space, decodes them to pixels, and runs
 `compute_all_metrics(reals, fakes)` (when combra is installed). All returned
 metrics — angle-Wasserstein `w1`, `w2`, `circular_w1`, `circular_w2`, the
 bimodal-Gaussian relative errors `mu1`/`mu2`/`sigma1`/`sigma2`/`amp1`/`amp2`, and
@@ -60,6 +61,33 @@ than a 10k subsample. (Set `--num-fid-samples 0` to disable eval entirely.)
 To keep the larger per-tick generation affordable, the EMA model's sampling
 forward is `torch.compile`d, which speeds up the reverse-diffusion latent
 generation that dominates evaluation time.
+
+### Samplers
+
+The reverse-diffusion sampler used for evaluation **and** inference is selectable.
+All three reuse the same trained model — they only differ in how the reverse
+process is integrated:
+
+- **`ddim`** *(default)* — deterministic DDIM. Reproducible (low-variance) metric
+  curves and good quality at moderate step counts; the recommended default for the
+  training-time eval signal and for final inference.
+- **`dpm++`** — DPM-Solver++(2M). Fastest (near-converged quality in ~25 steps);
+  use it for the cheapest possible training-time eval.
+- **`ddpm`** — stochastic ancestral sampling. Most faithful / most diverse at high
+  step counts (~250), but the slowest.
+
+During training, pick the eval sampler with `--eval-sampler` and its step count
+with `--eval-sampling-steps` (per-sampler defaults: `dpm++`=25, `ddim`=100,
+`ddpm`=250):
+
+```bash
+diffit-train --outdir=./training-runs --cfg=diffit-256 \
+    --data=./datasets/wc_co_256.zip --gpus 2 --batch-gpu 96 \
+    --eval-sampler ddim --eval-sampling-steps 100
+```
+
+The standalone `scripts.sample` and `diffit-gen-images` take the same choice via
+`--sampler` (which replaces the former `--use-ddim` flag).
 
 ### Dry run
 
@@ -84,7 +112,8 @@ on bulk-sampled `.npz` batches:
 torchrun --nproc_per_node=4 -m scripts.sample \
     --model-path ./training-runs/00000-diffit-256-*/network-final.pt \
     --outdir ./samples/256 --image-size 256 \
-    --cfg-scale 4.4 --num-samples 50000 --num-sampling-steps 250 --cfg-cond
+    --cfg-scale 4.4 --num-samples 50000 \
+    --sampler ddim --num-sampling-steps 250 --cfg-cond
 
 diffit-eval \
     --ref-batch ./VIRTUAL_imagenet256_labeled.npz \
@@ -120,7 +149,7 @@ diffit-gen-images \
     --samples-per-class 1000 \
     --classes 0,1,2 \
     --cfg-scale 4.4 \
-    --num-sampling-steps 250 \
+    --sampler ddim --num-sampling-steps 250 \
     --gpus 0,1,2,3 \
     --batch-size 32
 ```


### PR DESCRIPTION
## Summary
Expanded the DiffiT training documentation to clarify evaluation metrics, sampling strategies, and training configuration options. These changes improve clarity for users running training and inference workflows.

## Key Changes
- **Evaluation metrics**: Clarified that evaluation generates images via reverse-diffusion sampling (DDIM by default) in VAE latent space before computing metrics. Added details on the new bimodal-Gaussian relative error metrics (`mu1`/`mu2`/`sigma1`/`sigma2`/`amp1`/`amp2`) returned by combra.
- **Sample count behavior**: Documented the distinction between combra-disabled (uses `--num-fid-samples`, default 10k) and combra-enabled (scores entire training dataset) evaluation modes.
- **Sampling performance**: Added note about `torch.compile` optimization for evaluation sampling.
- **New Samplers section**: Documented three available reverse-diffusion samplers (DDIM, DPM++, DDPM) with their tradeoffs, step count defaults, and configuration via `--eval-sampler` and `--eval-sampling-steps` flags.
- **Dry-run feature**: Added documentation for the `-n`/`--dry-run` flag to validate configuration without starting training.
- **Updated examples**: Modified `scripts.sample` and `diffit-gen-images` examples to use the new `--sampler` flag (replacing the former `--use-ddim` flag).

## Implementation Details
All changes are documentation-only (`.md` file updates). The diff reflects expanded explanations of existing functionality and new configuration options that are already implemented in the codebase.

https://claude.ai/code/session_01KY2mLeedmeuuX6btm3QmuY