### PR TITLE
Add sampler comparison tools for step-count optimization

### DIFF
--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -4,6 +4,7 @@ The `combra.metrics` module bundles three families of metrics:
 
 - **Training-loop / batch metrics** — score generated images on the fly (no parquet round-trip): classic InceptionV3 FID (`compute_fid`), CLIP-MMD (`compute_cmmd`), Fréchet distance on DINOv2 features (`compute_fd_dinov2`), the four angle-Wasserstein distances between two samples' angle densities (`compute_wasserstein_metrics`), and the bimodal-Gaussian fit relative errors (`compute_gauss_metrics`). Every metric takes **in-memory images** (a numpy array or torch tensor), not a folder of files. Each side may be a **single image or a batch** (Wasserstein, Gaussian and CMMD are valid on one image; the Fréchet-distance metrics FID/FD-DINOv2 need ≥ 2). `compute_all_metrics` runs the whole set — FID included — in one call. Every two-input metric takes the *reference* first, then the *generated*.
 - **Distribution comparison helpers** — for comparing per-class angle distributions stored as parquet files.
+- **Sampler comparison** — sweep a diffusion sampler over a range of step counts, score each batch with the training-loop metrics, and plot metric-vs-steps (`compare_samplers`, `plot_sampler_comparison`) to see how many steps a sampler needs for good quality.
 - **Convergence analysis** — N-sweep aggregation, Kendall trend tests, plateau fits, and the convergence-grid / gain-distribution plots used by `3_metrics_convergence.ipynb`.
 
 ```python
@@ -713,6 +714,85 @@ Drive it over several `(resolution, generator)` sources and save one tidy parque
 ...                'class_2': 'class_Ultra_Co6_2'},
 ...     ns=[100, 250, 1000, 10000], step=2.0)
 >>> pd.DataFrame.from_records(recs).to_parquet('all_metrics_vs_n.parquet', index=False)
+```
+````
+
+## Sampler comparison
+
+Answer *how many reverse-diffusion steps `k` does a sampler need for good quality?*
+For each sampler and each step count, generate a batch, score it against a fixed
+real reference batch with `compute_all_metrics`, and plot metric (Y) vs. `k` (X),
+one curve per sampler. `compare_samplers` is sampler- and codebase-agnostic — the
+caller supplies the generators — so the same function drives any diffusion model
+(see `docs/examples/sampler_comparison.md` for the DiffiT-v2 wiring). They live in
+`combra.metrics.samplers` and `combra.metrics.plot`.
+
+````{py:function} combra.metrics.compare_samplers(reference_images, samplers, k_values, *, step=None, device=None, image_metrics=True, metrics=None, angle_kw=None, verbose=True) -> pandas.DataFrame
+
+Sweep each sampler over `k_values`, scoring the generated batch against a fixed reference with `compute_all_metrics`. A single `reference_cache` is reused across every call, so the reference-side work (FID/CMMD/DINOv2 features, angle density) runs only once.
+
+:param reference_images: Fixed batch of real reference images (numpy array or torch tensor).
+:type reference_images: ndarray or torch.Tensor
+:param samplers: Mapping `name -> fn(k)` where `fn(k)` returns a batch of generated images produced with `k` sampling steps.
+:type samplers: dict[str, callable]
+:param k_values: Step counts to sweep (e.g. `[5, 10, 20, 50, 100, 250]`).
+:type k_values: list[int]
+:param step: Angle-histogram bin width in degrees forwarded to `compute_all_metrics`. Default: `None` (5.0°).
+:type step: float or None, optional
+:param device: Torch device for the image-feature metrics. Default: `None`.
+:type device: str or None, optional
+:param image_metrics: If `True`, also compute FID / CMMD / FD-DINOv2. Angle metrics are always computed. Default: `True`.
+:type image_metrics: bool, optional
+:param metrics: Restrict the returned metric columns to this subset. Default: every key from `compute_all_metrics`.
+:type metrics: list[str] or None, optional
+:param angle_kw: Extra keyword arguments forwarded to the angle-extraction pipeline. Default: `None`.
+:type angle_kw: dict or None, optional
+:param verbose: Print a line per `(sampler, k)`. Default: `True`.
+:type verbose: bool, optional
+:returns: **df** (*pd.DataFrame*) – One row per `(sampler, k)` with columns `sampler`, `k`, and one column per metric.
+:rtype: pandas.DataFrame
+
+**Example**
+
+```python
+>>> from combra.metrics import compare_samplers, plot_sampler_comparison
+>>> samplers = {'ddim': ddim_fn, 'unipc': unipc_fn}   # fn(k) -> generated batch
+>>> df = compare_samplers(real_batch, samplers, k_values=[5, 10, 20, 50, 100, 250])
+>>> plot_sampler_comparison(df, save_path='sampler_comparison.png')
+```
+````
+
+````{py:function} combra.metrics.plot_sampler_comparison(df, metrics=None, x_col='k', sampler_col='sampler', metric_labels=None, log_x=True, n_cols=4, title=None, save_path=None, png_meta=None, fonts=None, height_per_row=420, width_per_col=520) -> plotly.graph_objects.Figure
+
+Small-multiples of every metric vs. sampling steps: one subplot per metric, X = `k`, Y = metric value, one curve per sampler. The companion plot to `compare_samplers`.
+
+:param df: Tidy DataFrame from `compare_samplers` (columns `sampler`, `k`, and one per metric).
+:type df: pd.DataFrame
+:param metrics: Metric columns to tile. Default: every column except `sampler_col` / `x_col`.
+:type metrics: list[str] or None, optional
+:param x_col: Column holding the step count. Default: `'k'`.
+:type x_col: str, optional
+:param sampler_col: Column holding the sampler name. Default: `'sampler'`.
+:type sampler_col: str, optional
+:param metric_labels: `{metric: subplot_title}`. Default: the metric key.
+:type metric_labels: dict[str, str] or None, optional
+:param log_x: Log-scale the `k` axis. Default: `True`.
+:type log_x: bool, optional
+:param n_cols: Subplots per row. Default: `4`.
+:type n_cols: int, optional
+:param title: Figure title. Default: `'Sampler comparison'`.
+:type title: str or None, optional
+:param save_path: If given, also render the figure to this PNG path. Default: `None`.
+:type save_path: str or None, optional
+:returns: **fig** (*plotly.graph_objects.Figure*) – The metric-vs-k figure.
+:rtype: plotly.graph_objects.Figure
+
+**Example**
+
+```python
+>>> from combra.metrics import plot_sampler_comparison
+>>> fig = plot_sampler_comparison(df, metrics=['fid', 'cmmd', 'fd_dinov2', 'w1'])
+>>> fig.show()
 ```
 ````
 

--- a/docs/examples/diffit.md
+++ b/docs/examples/diffit.md
@@ -160,12 +160,16 @@ process is integrated:
   training-time eval signal and for final inference.
 - **`dpm++`** — DPM-Solver++(2M). Fastest (near-converged quality in ~25 steps);
   use it for the cheapest possible training-time eval.
+- **`unipc`** — UniPC (Unified Predictor-Corrector, via diffusers'
+  `UniPCMultistepScheduler`). Like `dpm++` it subsamples the full 1000-step
+  schedule and converges in very few steps (~20); a solid fast-sampler
+  alternative to DPM-Solver++.
 - **`ddpm`** — stochastic ancestral sampling. Most faithful / most diverse at high
   step counts (~250), but the slowest.
 
 During training, pick the eval sampler with `--eval-sampler` and its step count
-with `--eval-sampling-steps` (per-sampler defaults: `dpm++`=25, `ddim`=100,
-`ddpm`=250):
+with `--eval-sampling-steps` (per-sampler defaults: `dpm++`=25, `unipc`=20,
+`ddim`=100, `ddpm`=250):
 
 ```bash
 diffit-train --outdir=./training-runs --cfg=diffit-256 \

--- a/docs/examples/sampler_comparison.md
+++ b/docs/examples/sampler_comparison.md
@@ -1,0 +1,80 @@
+# Comparing samplers — how many steps for good quality?
+
+A trained diffusion model can be sampled with different reverse-diffusion
+samplers, and each needs a different number of steps `k` to reach good quality.
+This example sweeps every sampler over a range of `k` and plots the combra
+metrics against `k`, so you can read off the cheapest step count that still
+produces good images.
+
+The workflow has two halves:
+
+- **combra** provides the generic, codebase-agnostic sweep + plot:
+  {py:func}`combra.metrics.compare_samplers` and
+  {py:func}`combra.metrics.plot_sampler_comparison`.
+- **DiffiT-v2** provides the wiring that turns a trained checkpoint and its four
+  samplers (`dpm++`, `unipc`, `ddim`, `ddpm`) into the generator callbacks that
+  combra needs — the `diffit-compare-samplers` script.
+
+## The idea
+
+For each sampler and each `k`, generate a batch of samples, score it against a
+fixed batch of **real** reference images with
+{py:func}`combra.metrics.compute_all_metrics` (`image_metrics=True` adds FID /
+CMMD / FD-DINOv2 on top of the angle-Wasserstein and bimodal-Gaussian metrics),
+and collect one row per `(sampler, k)`. The plot then tiles one subplot per
+metric with **Y = metric** and **X = k**, one curve per sampler.
+
+`compare_samplers` never imports any diffusion code — the caller passes a
+`{name: fn(k)}` mapping where `fn(k)` returns a generated batch — so the same
+function works for any generator.
+
+## Running it on DiffiT-v2
+
+`diffit-compare-samplers` loads a checkpoint, pulls `--num-samples` real
+reference images from the same dataset used for training (`--data`), builds a
+`fn(k)` for each requested sampler, and calls `compare_samplers` for you. It
+writes a tidy `sampler_comparison.parquet` and a `sampler_comparison.png`.
+
+```bash
+diffit-compare-samplers \
+    --model-path ./runs/wc_cv_combra/network-final.pt \
+    --data ./datasets/imagenet_9to4_1024x1024_256x256.zip \
+    --image-size 256 --cfg-scale 4.4 --num-samples 512 \
+    --samplers dpm++,unipc,ddim,ddpm \
+    --k-values 5,10,20,50,100,250 \
+    --outdir ./sampler-comparison/256
+```
+
+On a SLURM cluster, submit the ready-made batch script — it mirrors the training
+sbatch (same `--data` / model config), so the comparison scores the model on the
+dataset it was trained on:
+
+```bash
+sbatch sbatch/h200_compare_samplers_256x256.sbatch
+```
+
+## Calling combra directly
+
+If you already have generator callbacks (from any model), skip the DiffiT script
+and call combra directly:
+
+```python
+>>> from combra.metrics import compare_samplers, plot_sampler_comparison
+>>>
+>>> # fn(k) -> a batch of generated images produced with k sampling steps
+>>> samplers = {'dpm++': dpmpp_fn, 'unipc': unipc_fn, 'ddim': ddim_fn}
+>>> df = compare_samplers(
+...     real_batch, samplers, k_values=[5, 10, 20, 50, 100, 250],
+...     image_metrics=True,
+... )
+>>> df.head()
+  sampler    k     fid    cmmd  fd_dinov2      w1   ...
+0   dpm++    5   38.10   0.512      412.3   6.204   ...
+1   dpm++   10   22.47   0.331      280.1   4.118   ...
+...
+>>> plot_sampler_comparison(df, save_path='sampler_comparison.png')
+```
+
+Read the answer off the curves: the `k` where each sampler's FID (and the other
+metrics) flattens out is the step budget it needs — fast samplers like `unipc`
+and `dpm++` typically plateau far earlier than `ddim` / `ddpm`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ examples/angles
 examples/fid
 examples/san_v2
 examples/diffit
+examples/sampler_comparison
 ```
 
 ## Module map
@@ -55,7 +56,7 @@ examples/diffit
 | {doc}`combra.areas <api/areas>` | Polygon-area and effective-radius distribution plots. |
 | {doc}`combra.stats <api/stats>` | Parametric distributions + histogram preprocessor. |
 | {doc}`combra.approx <api/approx>` | Fits Gaussian/binomial/poisson/exponential/linear models. |
-| {doc}`combra.metrics <api/metrics>` | FID, batch generative-quality metrics (CMMD, FD-DINOv2, angle-Wasserstein), per-class Wasserstein comparison, and convergence-vs-N analysis. |
+| {doc}`combra.metrics <api/metrics>` | FID, batch generative-quality metrics (CMMD, FD-DINOv2, angle-Wasserstein), per-class Wasserstein comparison, sampler-vs-steps comparison, and convergence-vs-N analysis. |
 | {doc}`combra.graph <api/graph>` | Crack-image → graph → shortest-energy-path search. |
 | {doc}`combra.utils <api/utils>` | `NumpyEncoder` for JSON dumps. |
 | {doc}`combra.tests <api/tests>` | Self-validation helpers (fractal-dimension sanity check). |


### PR DESCRIPTION
## Summary

Adds generic, codebase-agnostic tools to sweep diffusion samplers over a range of step counts, score each configuration against a fixed reference batch, and visualize metric-vs-steps curves. This enables users to determine the minimum step budget needed for good quality on any sampler.

## Changes

- **New API functions** (`combra.metrics.samplers` and `combra.metrics.plot`):
  - `compare_samplers()` — sweeps each sampler over `k_values`, scoring generated batches against a fixed reference with `compute_all_metrics`. Reuses a single reference cache across all calls for efficiency.
  - `plot_sampler_comparison()` — creates small-multiples visualization (one subplot per metric, one curve per sampler) with log-scale step axis and customizable layout.

- **Documentation**:
  - Added "Sampler comparison" section to `docs/api/metrics.md` with full API reference and usage example.
  - New example guide `docs/examples/sampler_comparison.md` explaining the workflow, DiffiT-v2 integration, and direct usage patterns.
  - Updated `docs/examples/diffit.md` to document the new `unipc` sampler option and its default step count (20).
  - Updated `docs/index.md` module map and examples index to include sampler comparison.

## Implementation notes

- The functions are sampler- and codebase-agnostic: callers supply `fn(k) -> batch` callbacks, so the same sweep logic works for any diffusion model.
- Reference-side computation (FID/CMMD/DINOv2 features, angle density) runs only once and is cached across all sampler/k combinations.
- Metrics can be restricted via the `metrics` parameter; angle metrics are always computed.
- The plot uses log-scale X-axis by default to better visualize the convergence behavior across wide step ranges.

https://claude.ai/code/session_014chjkETUNDY9YQqeSaSGnG