### PR TITLE
docs: document the v0.5 API-convention slice (Bunch, load_microstruct…

### DIFF
--- a/docs/_static/source_index.json
+++ b/docs/_static/source_index.json
@@ -40,6 +40,54 @@
   "end": 91
  },
  {
+  "leaf": "AngleDensityDisplay",
+  "qual": "AngleDensityDisplay",
+  "subpkg": "angles",
+  "file": "combra/angles/display.py",
+  "start": 17,
+  "end": 126
+ },
+ {
+  "leaf": "__init__",
+  "qual": "AngleDensityDisplay.__init__",
+  "subpkg": "angles",
+  "file": "combra/angles/display.py",
+  "start": 37,
+  "end": 44
+ },
+ {
+  "leaf": "__repr__",
+  "qual": "AngleDensityDisplay.__repr__",
+  "subpkg": "angles",
+  "file": "combra/angles/display.py",
+  "start": 46,
+  "end": 47
+ },
+ {
+  "leaf": "from_row",
+  "qual": "AngleDensityDisplay.from_row",
+  "subpkg": "angles",
+  "file": "combra/angles/display.py",
+  "start": 50,
+  "end": 60
+ },
+ {
+  "leaf": "from_parquet",
+  "qual": "AngleDensityDisplay.from_parquet",
+  "subpkg": "angles",
+  "file": "combra/angles/display.py",
+  "start": 63,
+  "end": 71
+ },
+ {
+  "leaf": "plot",
+  "qual": "AngleDensityDisplay.plot",
+  "subpkg": "angles",
+  "file": "combra/angles/display.py",
+  "start": 73,
+  "end": 126
+ },
+ {
   "leaf": "angles_out_dir",
   "qual": "angles_out_dir",
   "subpkg": "angles",
@@ -532,56 +580,64 @@
   "qual": "pkg",
   "subpkg": "data",
   "file": "combra/data/fetchers.py",
-  "start": 8,
-  "end": 8
+  "start": 10,
+  "end": 10
  },
  {
   "leaf": "_fetch_images_from_path",
   "qual": "_fetch_images_from_path",
   "subpkg": "data",
   "file": "combra/data/fetchers.py",
-  "start": 11,
-  "end": 17
+  "start": 21,
+  "end": 27
  },
  {
   "leaf": "_fetch_jsons_from_path",
   "qual": "_fetch_jsons_from_path",
   "subpkg": "data",
   "file": "combra/data/fetchers.py",
-  "start": 20,
-  "end": 26
+  "start": 30,
+  "end": 36
  },
  {
   "leaf": "microstructure_images",
   "qual": "microstructure_images",
   "subpkg": "data",
   "file": "combra/data/fetchers.py",
-  "start": 29,
-  "end": 38
+  "start": 39,
+  "end": 40
+ },
+ {
+  "leaf": "load_microstructure",
+  "qual": "load_microstructure",
+  "subpkg": "data",
+  "file": "combra/data/fetchers.py",
+  "start": 43,
+  "end": 73
  },
  {
   "leaf": "crack_images",
   "qual": "crack_images",
   "subpkg": "data",
   "file": "combra/data/fetchers.py",
-  "start": 41,
-  "end": 43
+  "start": 76,
+  "end": 78
  },
  {
   "leaf": "crack_labeled_json",
   "qual": "crack_labeled_json",
   "subpkg": "data",
   "file": "combra/data/fetchers.py",
-  "start": 46,
-  "end": 48
+  "start": 81,
+  "end": 83
  },
  {
   "leaf": "microstructure_class_path",
   "qual": "microstructure_class_path",
   "subpkg": "data",
   "file": "combra/data/fetchers.py",
-  "start": 51,
-  "end": 53
+  "start": 86,
+  "end": 88
  },
  {
   "leaf": "_attr_str",
@@ -2048,19 +2104,59 @@
   "end": 129
  },
  {
+  "leaf": "Bunch",
+  "qual": "Bunch",
+  "subpkg": "utils",
+  "file": "combra/utils/build.py",
+  "start": 6,
+  "end": 32
+ },
+ {
+  "leaf": "__init__",
+  "qual": "Bunch.__init__",
+  "subpkg": "utils",
+  "file": "combra/utils/build.py",
+  "start": 19,
+  "end": 20
+ },
+ {
+  "leaf": "__getattr__",
+  "qual": "Bunch.__getattr__",
+  "subpkg": "utils",
+  "file": "combra/utils/build.py",
+  "start": 22,
+  "end": 26
+ },
+ {
+  "leaf": "__setattr__",
+  "qual": "Bunch.__setattr__",
+  "subpkg": "utils",
+  "file": "combra/utils/build.py",
+  "start": 28,
+  "end": 29
+ },
+ {
+  "leaf": "__dir__",
+  "qual": "Bunch.__dir__",
+  "subpkg": "utils",
+  "file": "combra/utils/build.py",
+  "start": 31,
+  "end": 32
+ },
+ {
   "leaf": "NumpyEncoder",
   "qual": "NumpyEncoder",
   "subpkg": "utils",
   "file": "combra/utils/build.py",
-  "start": 6,
-  "end": 14
+  "start": 35,
+  "end": 43
  },
  {
   "leaf": "default",
   "qual": "NumpyEncoder.default",
   "subpkg": "utils",
   "file": "combra/utils/build.py",
-  "start": 7,
-  "end": 14
+  "start": 36,
+  "end": 43
  }
 ]

--- a/docs/api/angles.md
+++ b/docs/api/angles.md
@@ -352,6 +352,57 @@ From `co_angles/1_generation_and_plots.ipynb` — one call per N draws the grid 
 ```
 ````
 
+## Display
+
+````{py:class} combra.angles.AngleDensityDisplay(density, gauss_curve, *, name='', itype='', step=None, legend=None)
+
+Angle-density curve + bimodal-Gaussian fit for one grain class, following
+scikit-learn's `*Display` convention (cf. `RocCurveDisplay`): the *computed*
+values are stored as attributes, drawing is a separate `plot` step, and
+alternate constructors build one from stored data. `plot` accepts an existing
+plotly figure (the `ax=` analogue) and **never** calls `fig.show()`.
+
+```{versionadded} 0.5
+```
+
+**Attributes**
+
+- **`density`** — `(x, y)` of the angle-histogram density.
+- **`gauss_curve`** — `(x, y)` of the fitted bimodal-Gaussian curve.
+- **`name`, `itype`, `step`, `legend`** — metadata copied from the parquet row.
+- **`figure_`** — the figure produced by the last `plot` call (set only after `plot`).
+
+**Constructors**
+
+```{py:classmethod} from_row(row)
+Build from one `{'meta': ..., 'prep': ...}` row (see {py:func}`combra.metrics.load_rows`).
+```
+
+```{py:classmethod} from_parquet(path, class_name, step)
+Load an angles parquet and select the `(class_name, step)` row.
+```
+
+**Method**
+
+```{py:method} plot(fig=None, *, row=None, col=None, color='orange', marker='square', scatter_size=8, show_legend=True, name=None)
+Draw the density markers + fitted curve onto `fig` (a new figure if `None`; pass
+`row`/`col` to target a subplot cell) and return it. Stores it on `figure_`.
+```
+
+**Example**
+
+```python
+>>> from combra.angles import AngleDensityDisplay
+>>> from plotly.subplots import make_subplots
+>>> fig = make_subplots(rows=1, cols=2)
+>>> AngleDensityDisplay.from_parquet('angles_n360.parquet', 'Ultra_Co11', step=2.0) \
+...     .plot(fig=fig, row=1, col=1, color='blue')
+>>> AngleDensityDisplay.from_parquet('gen/angles_n10000.parquet', 'class_1', step=2.0) \
+...     .plot(fig=fig, row=1, col=2, color='orange')
+>>> fig.show()   # the caller displays — the library never does
+```
+````
+
 ## See also
 
 - {py:meth}`combra.data.PobeditDataset.generate_angles` — drives `vertex_angles` across whole class folders and writes parquet.

--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -30,6 +30,31 @@ Load the five SEM example images shipped with combra (`Ultra_Co{6_2, 8, 11, 15, 
 ```
 ````
 
+````{py:function} combra.data.load_microstructure() -> combra.utils.Bunch
+
+Load the bundled 5-class microstructure sample as a scikit-learn-style
+{py:class}`~combra.utils.Bunch` — the self-describing counterpart of
+{py:func}`~combra.data.microstructure_images`. Class names are **alphabetically
+sorted** and the integer `target` is index-aligned to them.
+
+```{versionadded} 0.5
+```
+
+:returns: **data** – a {py:class}`~combra.utils.Bunch` with `images` (list of `uint8` arrays), `target` (int class-index array), `class_names` (sorted grain names), `filenames`, and `DESCR`.
+:rtype: combra.utils.Bunch
+
+**Example**
+
+```python
+>>> from combra import data
+>>> ds = data.load_microstructure()
+>>> ds.class_names
+['Ultra_Co11', 'Ultra_Co15', 'Ultra_Co25', 'Ultra_Co6_2', 'Ultra_Co8']
+>>> ds.images[0].shape, int(ds.target[0])
+((..., ...), 0)
+```
+````
+
 ````{py:function} combra.data.microstructure_class_path() -> str
 
 Return the path to the bundled 5-class WC/Co directory tree (one subfolder per class).

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -6,6 +6,31 @@ Small helpers shared across combra.
 from combra import utils
 ```
 
+## Bunch
+
+````{py:class} combra.utils.Bunch(**kwargs)
+
+A `dict` that also exposes its keys as attributes — the scikit-learn container
+convention (`sklearn.utils.Bunch`). Dataset loaders such as
+{py:func}`combra.data.load_microstructure` return one so results are
+self-describing (`ds.images`, `ds.class_names`) while still behaving as a plain
+`dict`. Assigning a new attribute adds a key.
+
+```{versionadded} 0.5
+```
+
+**Example**
+
+```python
+>>> from combra.utils import Bunch
+>>> b = Bunch(images=[...], class_names=['Ultra_Co11', 'Ultra_Co25'])
+>>> b.class_names[0]
+'Ultra_Co11'
+>>> b['class_names'] is b.class_names   # dict access too
+True
+```
+````
+
 ## NumpyEncoder
 
 ````{py:class} combra.utils.NumpyEncoder(json.JSONEncoder)


### PR DESCRIPTION
…ure, Display)

- utils: combra.utils.Bunch (sklearn attribute-dict container)
- data: combra.data.load_microstructure() Bunch loader alongside microstructure_images
- angles: combra.angles.AngleDensityDisplay (sklearn *Display pattern) with from_row / from_parquet constructors and a compose-friendly plot()
- regenerated _static/source_index.json so the new symbols get [source] links

Strict Sphinx build (-W) passes; source links verified.


Claude-Session: https://claude.ai/code/session_015ezpdfRYD55kVMjXT4t34f