### PR TITLE
docs: update DiffiT-v2 training, evaluation, and API conventions

### DIFF
--- a/docs/examples/diffit.md
+++ b/docs/examples/diffit.md
@@ -18,9 +18,11 @@ pip install combra            # or: pip install 'diffit[combra]'
 ## Training
 
 `diffit-train` trains the model; **"from scratch" simply means launching without
-`--resume`** (random initialisation). DiffiT-v2 can also be trained progressively
-(low → high resolution) — RoPE-2D lets a 256² checkpoint be re-used at higher
-resolutions.
+`--init-weights`** (random initialisation). DiffiT-v2 can also be trained
+progressively (low → high resolution) — RoPE-2D lets a 256² checkpoint's EMA
+weights warm-start a higher-resolution stage via `--init-weights` (weights only,
+fresh optimizer). There is no `--resume`: runs go start-to-finish (see
+Checkpoints).
 
 ### From scratch
 
@@ -49,30 +51,41 @@ resolutions.
 3. **Prepare the dataset.** `diffit-prepare-data` center-crops and resizes a folder
    of images into a `.zip` the trainer reads:
 
+   `diffit-prepare-data` is a click group; the `convert` subcommand builds the zip:
+
    ```bash
-   diffit-prepare-data --source ./raw_wc_co_images \
+   diffit-prepare-data convert --source ./raw_wc_co_images \
        --dest ./datasets/wc_co_256x256.zip \
        --resolution 256x256 --transform center-crop
    ```
 
-   Class labels come from a `dataset.json` inside the `.zip`
-   (`{"labels": [["img.png", classID], ...]}`); if you instead point `--data` at a
-   plain directory, the class is the filename prefix before `_` (e.g. `wc_001.png` →
-   class `wc`). Grayscale SEM images are supported, and single-class data is fine
-   (all files share one prefix / label).
+   The transform set is `center-crop` / `center-crop-wide` / `center-crop-dhariwal`.
+   The `.zip`'s `dataset.json` carries both the integer `labels` and an
+   index-aligned `class_names` list (§5 label contract), where the integer label
+   is the class-folder index in **alphabetical** order. `class_names` then travels
+   into every checkpoint and every generated `.h5`, so grain-class identity is
+   recoverable without a `CLASS_MAP`. Grayscale SEM images are converted to RGB
+   **at build time** (the loader asserts 3 channels rather than converting
+   silently). If you point `--data` at a plain directory instead, the class is the
+   immediate parent folder name (alphabetical). A dataset with any unlabeled image
+   is rejected rather than silently demoted to unconditional.
 
 4. **Launch training.** The required flags are `--outdir`, `--cfg`, `--data`,
    `--gpus`, `--batch-gpu`; the presets are `diffit-256`, `diffit-512`,
    `diffit-1024`:
 
    ```bash
-   # 256² from scratch (no --resume → random init)
+   # 256² from scratch (no --init-weights → random init)
    diffit-train --outdir=./training-runs \
        --cfg=diffit-256 \
        --data=./datasets/wc_co_256x256.zip \
        --gpus 2 \
        --batch-gpu 96
    ```
+
+   The total batch is `batch-gpu × gpus × grad-accum`. Precision is chosen with
+   `--precision {fp32,fp16,bf16}` (default `bf16`); boolean flags take an explicit
+   value (`--tf32 True`, `--bench True`, `--mirror False`, `--cache-in-ram True`).
 
 ### Quick example (single-GPU smoke test)
 
@@ -94,7 +107,8 @@ default).
 
 ### Progressive finetuning
 
-Each higher-resolution stage resumes from the previous stage's `network-final.pt`:
+Each higher-resolution stage warm-starts from the previous stage's EMA snapshot
+via `--init-weights` (weights only, fresh optimizer — not a resume):
 
 ```bash
 # 256² → 512² finetune
@@ -102,30 +116,27 @@ diffit-train --outdir=./training-runs \
     --cfg=diffit-512 \
     --data=./datasets/wc_co_512x512.zip \
     --gpus 2 --batch-gpu 64 \
-    --resume ./training-runs/00000-diffit-256-*/network-final.pt \
+    --init-weights ./training-runs/00000-diffit-256-*/diffit-snapshot-000400-inference.pt \
     --lr 5e-5 --lr-warmup 500 --kimg 100000
 ```
 
 ### Checkpoints
 
-At every snapshot tick (every `--snap` ticks) the run directory accumulates a
-small inference snapshot for history and keeps single, non-growing full
-checkpoints for resume:
+There is exactly one checkpoint kind — no resume, no best-model tracking, no
+separate final checkpoint:
 
 | File | Contents | Cadence |
 | --- | --- | --- |
-| `network-snapshot-<kimg>-inference.pt` | G_ema weights only (smallest artifact for `diffit-sample` / `diffit-gen-images`) | every tick; only the newest `--snapshot-keep-last` (default 3) are kept |
-| `network-snapshot-latest.pt` | full `{model, ema, opt, scaler?, cur_nimg}` for `--resume` | overwritten in place each tick (skipped under `--save-inference-only`) |
-| `best_model.pt` | full checkpoint of the lowest-FID tick (`combra_fid10k`, else `FID`) | rewritten only when FID improves; never pruned |
-| `network-final.pt` / `network-final-inference.pt` | full / G_ema-only final model | once at end |
+| `diffit-snapshot-<kimg>-inference.pt` | EMA weights only + self-describing metadata (`n_classes`, `resolution`, `class_names`, `cur_nimg`) | every `--snap` ticks **and always at the last tick**; only the newest `--snapshot-keep-last` (default 3, `0` = keep all) are kept |
 
-This keeps disk bounded — the full optimizer state lives in exactly one rolling
-file rather than one per tick. Resume from whichever full checkpoint you want:
-`network-snapshot-latest.pt` for the most recent step, or `best_model.pt` for the
-best-scoring one. `--save-inference-only` skips the rolling `network-snapshot-latest.pt`
-(so a run writes no repeated optimizer state), but `best_model.pt` and the final
-`network-final.pt` are still full checkpoints, so resume — and progressive
-finetuning from a previous stage — always work.
+Only EMA weights ever touch disk — raw model weights and optimizer state are
+never saved. Every snapshot is written **atomically** (temp file + `os.replace`),
+so a snapshot present under its final name is always complete, and the last tick
+always snapshots, so the newest snapshot *is* the final model. Runs are
+unrecoverable by design (a crash or SLURM walltime kill cannot be resumed) — size
+`--kimg` (or split into progressive stages via `--init-weights`) so a run fits its
+job's time limit. Pick the best checkpoint post-hoc from `stats.jsonl` against the
+snapshot history (set `--snapshot-keep-last 0` to keep them all).
 
 During training, at each evaluation tick (every `--snap` ticks) the loop
 generates a batch of images from the EMA model by running the configured
@@ -164,12 +175,18 @@ fixes a multi-GPU hang: when it ran rank-0-only over the full gathered batch, at
 512²/1024² it could take longer than NCCL's watchdog while the other ranks idled,
 aborting the job.
 
-**Sample count.** When combra is **not** installed, the eval generates
-`--num-fid-samples` images (default 10000), unchanged. When combra **is**
-installed, each evaluation tick instead scores the **whole training dataset**:
-the reference is every real image used once, and DiffiT generates a matching
-number of images. This makes the combra metrics a full-dataset measurement rather
-than a 10k subsample. (Set `--num-fid-samples 0` to disable eval entirely.)
+**Sample count.** `--num-fid-samples` (default 10000) governs the number of fakes
+generated each tick for both the combra and the Inception path. The combra
+reference is the **whole training set** by default; `--combra-ref-count N` caps it
+to a **seeded random subset** of `N` reals (never the first N — dataset zips are
+class-sorted, so a first-N slice would be class-biased). The `10k` suffix in the
+metric keys (`Metrics/combra_fid10k`, …) is literal and does not change with
+`--num-fid-samples`. Set `--num-fid-samples 0` to disable eval entirely.
+
+All per-tick scalars are written to `stats.jsonl` (one JSON line per tick,
+scalar rows only) and mirrored to TensorBoard under the `Loss/*`,
+`LearningRate/*`, `Timing/*`, `Resources/*`, `Metrics/*` and `Fakes` namespaces,
+with the global step counted in images (`cur_nimg`).
 
 To keep the larger per-tick generation affordable, the EMA model's sampling
 forward is `torch.compile`d, which speeds up the reverse-diffusion latent
@@ -218,12 +235,15 @@ diffit-train --outdir=./training-runs \
 
 ## Evaluation
 
-A full FID-50K evaluation of a trained checkpoint uses the standalone evaluator
-on bulk-sampled `.npz` batches:
+For WC-Co work, the in-training combra metrics and `diffit-gen-images` → the
+angle pipeline are the evaluation path. A legacy FID-50K evaluation of a trained
+checkpoint on bulk-sampled `.npz` batches is still available via the standalone
+evaluator, but `scripts.sample` is a **legacy** bulk-`.npz` sampler outside the v2
+generation contract (it carries no contract guarantees):
 
 ```bash
 torchrun --nproc_per_node=4 -m scripts.sample \
-    --model-path ./training-runs/00000-diffit-256-*/network-final.pt \
+    --model-path ./training-runs/00000-diffit-256-*/diffit-snapshot-000400-inference.pt \
     --outdir ./samples/256 --image-size 256 \
     --cfg-scale 4.4 --num-samples 50000 \
     --sampler ddim --num-sampling-steps 250 --cfg-cond
@@ -254,28 +274,40 @@ numpy arrays or torch tensors in `NCHW`/`NHWC`, with pixel values in `uint8`,
 
 ## Inference
 
-Generate individual images from a trained checkpoint with `diffit-gen-images`.
-Images are written per class into `class_<id>/...`; pass `--gpus` (or launch with
-`torchrun`) to distribute generation:
+Generate images from a trained checkpoint with `diffit-gen-images`. In the
+default `hdf5` save mode each GPU worker writes a per-rank shard and rank 0 merges
+them into `<desc>.h5` (the RankH5Writer layout the angle pipeline consumes, with
+`format="generated_images_shard"` / `schema_version=1` and `class_names` stamped
+in); `--save-mode dir` writes per-class PNGs plus a `classes.json`. `--gpus N`
+self-spawns one worker per GPU (no `torchrun`). Every image has its own seed
+(`base-seed + class·samples_per_class + idx`), so any subset is reproducible in
+isolation, and the merge hard-fails if any shard is incomplete:
 
 ```bash
 diffit-gen-images \
-    --model-path ./training-runs/00000-diffit-256-*/network-final.pt \
+    --network ./training-runs/00000-diffit-256-*/diffit-snapshot-000400-inference.pt \
     --outdir ./generated/ \
     --image-size 256 \
     --samples-per-class 1000 \
-    --classes 0,1,2 \
+    --classes Ultra_Co11,Ultra_Co25,Ultra_Co6_2 \
     --cfg-scale 4.4 \
-    --sampler ddim --num-sampling-steps 250 \
-    --gpus 0,1,2,3 \
-    --batch-size 32
+    --sampler ddim --steps 250 \
+    --gpus 4 \
+    --batch-gpu 32 \
+    --desc wc_co_256
 ```
+
+`--network` (alias `--model-path`) takes the checkpoint; `--steps` (alias
+`--num-sampling-steps`) sets the sampler steps; `--batch-gpu` is the per-GPU batch;
+`--classes` accepts class names or indices, validated against the checkpoint's
+`class_names` / `n_classes` metadata.
 
 ### Class index → grain class
 
-The `--classes` / `--class-idx` integer selects a grain morphology. Under the
-**alphabetical convention of `dataset_tool_for_imagenet.py`** the indices map
-as:
+The `--classes` selector accepts class **names** directly (validated against the
+checkpoint), so the index↔grain mapping no longer has to be memorised. Under the
+alphabetical convention now written into every new dataset's `class_names` the
+indices map as:
 
 | index | grain class | morphology |
 |---|---|---|
@@ -283,20 +315,24 @@ as:
 | `1` | `Ultra_Co25` | medium grain (средние зёрна) |
 | `2` | `Ultra_Co6_2` | large grain (крупные зёрна) |
 
+```{note}
+**New (post-contract) runs are self-describing.** `diffit-prepare-data` writes an
+index-aligned `class_names` into `dataset.json`; it flows into every checkpoint
+and every generated `.h5`, so combra matches by name and no `CLASS_MAP` is
+needed.
+```
+
 ```{warning}
-**The trained checkpoints most likely do NOT follow this table.** The table
-is the dataset *tool's* convention, but training takes zip labels
-**verbatim** (the startup class probe remaps sorted ints to contiguous ints —
-an identity map for `0,1,2`), and the on-disk `imagenet_9to4_*` archives the
-real runs consumed (e.g. run 00017, per its `training_options.json`) carry
-labels in **SAN's swapped order** (`0 → Ultra_Co25`, `1 → Ultra_Co11`,
-`2 → Ultra_Co6_2` — see {doc}`san_v2`). Classify each checkpoint by the
-dataset path in its `training_options.json` before assuming either
-convention, and do **not** apply a `CLASS_MAP` remap
+**Legacy checkpoints do NOT carry names and most likely do NOT follow this
+table.** Runs trained before the label contract took zip labels **verbatim**, and
+the on-disk `imagenet_9to4_*` archives the real runs consumed (e.g. run 00017, per
+its `training_options.json`) carry labels in **SAN's swapped order**
+(`0 → Ultra_Co25`, `1 → Ultra_Co11`, `2 → Ultra_Co6_2` — see {doc}`san_v2`).
+Classify each legacy checkpoint by the dataset path in its `training_options.json`
+before assuming either convention, and do **not** apply a `CLASS_MAP` remap
 (via {py:func}`combra.angles.resolve_overlay_rows` /
-{py:func}`combra.angles.build_overlay_grid` `gen_name_for_mode`) to a
-checkpoint trained on those archives — it would introduce the very swap it
-is meant to fix.
+{py:func}`combra.angles.build_overlay_grid` `gen_name_for_mode`) to a checkpoint
+trained on those archives — it would introduce the very swap it is meant to fix.
 ```
 
 **Why the order differs.** The dataset stores only an integer label per image — never
@@ -311,9 +347,11 @@ the `Ultra_Co*` name — and the two pipelines derive that integer by *different
 
 Because the source `dataset.json` lists `Co25` before `Co11` while the folder sort puts
 `Co11` first, the two conventions disagree on labels 0 and 1 — the `Co11`↔`Co25` swap.
-`Ultra_Co6_2` is last under both rules, so it stays `2`. **Which rule a checkpoint
-follows depends on which zip it trained on** — the shipped `imagenet_9to4_*` archives
-carry the SAN-order labels, whichever tool nominally built them. Since neither pipeline
-records the grain name downstream (the zips hold neither `class_names` nor original
-filenames, and generated h5s carry only `class_0/1/2`), the correspondence has to be
-recovered per run from `training_options.json` and pinned in combra's `CLASS_MAP`.
+`Ultra_Co6_2` is last under both rules, so it stays `2`. **Which rule a legacy
+checkpoint follows depends on which zip it trained on** — the shipped
+`imagenet_9to4_*` archives carry the SAN-order labels, whichever tool nominally built
+them. For those legacy artifacts, which recorded neither `class_names` nor original
+filenames, the correspondence has to be recovered per run from
+`training_options.json` and pinned in combra's `CLASS_MAP`. New DiffiT-v2 runs avoid
+the problem entirely: `class_names` is written into the zip, the checkpoint and every
+generated `.h5`, so identity travels with the artifact.

--- a/docs/examples/models_api.md
+++ b/docs/examples/models_api.md
@@ -11,6 +11,20 @@ remaining divergences — including per-repo migration deltas — is proposed in
 {doc}`models_api_proposal`.
 ```
 
+```{note}
+**DiffiT-v2 now implements the v2 convention** ({doc}`models_api_proposal` §12).
+Its checkpoint scheme (EMA-only `diffit-snapshot-<kimg>-inference.pt`, atomic,
+no resume/best/latest/final), training CLI (`--precision`, `True/False`
+booleans, `--init-weights`, `--mirror`), generation contract (`--network` /
+`--steps`, self-spawning `--gpus`, per-image seeds, unified
+`format="generated_images_shard"` / `schema_version=1` h5 merged to `<desc>.h5`),
+dataset/label contract (uint8 items, `class_names` in `dataset.json` /
+checkpoints / h5), logging (`stats.jsonl` scalar rows + §7 TensorBoard
+namespaces) and infrastructure (no Hydra, no `requirements.txt`, `sh/` launch
+scripts) all follow the spec. The DiffiT-v2 cells below reflect that; the other
+three repos still diverge as noted.
+```
+
 | repo | family | upstream | docs |
 |---|---|---|---|
 | [san-v2](https://github.com/dkagramanyan/san-v2) | GAN — StyleGAN3 + Projected GAN + SAN | Sony StyleSAN-XL | {doc}`san_v2` |
@@ -51,17 +65,18 @@ Every repo follows the same conventions:
   `network-snapshot-latest.pt` overwritten in place and a history of small
   inference snapshots, pruned to `--snapshot-keep-last` (default 3) —
   except in **san-v2**, where no pruning exists and snapshots accumulate
-  unbounded.
+  unbounded, and **DiffiT-v2**, which has dropped resume/best/latest entirely
+  and keeps only the pruned EMA-only inference snapshots (§12).
 
 ## Training
 
 | | san-v2 | StyleSwin-v2 | DiffiT-v2 | EDM2-v2 |
 |---|---|---|---|---|
 | entry point | `train.py` | `train.py` | `scripts/train.py` (`diffit-train`) | `train_edm2.py` (`edm2-train`) |
-| Hydra wrapper | `train_hydra.py` | **none** | `train_hydra.py` | `train_hydra.py` |
+| Hydra wrapper | `train_hydra.py` | **none** | **none** (removed) | `train_hydra.py` |
 | presets | `--cfg` = architecture (`stylegan3-r`, …) | `--cfg styleswin-{256,512,1024}` | `--cfg diffit-{256,512,1024}` | `--preset edm2-img{256,512,1024}-s` (+ more sizes) |
 | required flags | `--outdir --cfg --data --gpus --batch-gpu` | `--outdir --data --gpus` | `--outdir --cfg --data --gpus --batch-gpu` | `--outdir --data` |
-| resolution strategy | **progressive**: 16² stem, then superres stages (`--superres --up_factor 2 --path_stem`) | independent run per resolution | finetune upward via `--resume` (RoPE-2D) | independent preset per resolution (shared VAE latent space) |
+| resolution strategy | **progressive**: 16² stem, then superres stages (`--superres --up_factor 2 --path_stem`) | independent run per resolution | finetune upward via `--init-weights` (RoPE-2D) | independent preset per resolution (shared VAE latent space) |
 
 ## Evaluation
 
@@ -76,11 +91,11 @@ Every repo follows the same conventions:
 
 | | san-v2 | StyleSwin-v2 | DiffiT-v2 | EDM2-v2 |
 |---|---|---|---|---|
-| format | **pickled modules** (`.pkl`, loaded via `legacy.py`) | `.pt` state dicts | `.pt` state dicts | mixed: inference `.pkl` + resume `.pt` |
-| rolling full checkpoint | `network-snapshot-latest.pt` (`G`/`D`/`G_ema` + progress; **no optimizer state**) | `network-snapshot-latest.pt` (G, D, G_ema, both optimizers) | `network-snapshot-latest.pt` (model, ema, opt, scaler) | `network-snapshot-latest.pt` (state, net, loss, optimizer, ema) |
-| inference history (pruned) | `network-snapshot-<kimg>-inference.pkl` — only with `--save-inference-only 1` | `network-snapshot-<kimg>-inference.pt` — always | `network-snapshot-<kimg>-inference.pt` — always | `network-snapshot-<kimg>-<ema_std>.pkl` — always, one per EMA std |
-| best model | `best_model.pkl` | `best_model.pt` | `best_model.pt` | `best_model.pt` |
-| final artifact | — | — | `network-final.pt` / `network-final-inference.pt` | — |
+| format | **pickled modules** (`.pkl`, loaded via `legacy.py`) | `.pt` state dicts | `.pt` state dicts (EMA-only + metadata) | mixed: inference `.pkl` + resume `.pt` |
+| rolling full checkpoint | `network-snapshot-latest.pt` (`G`/`D`/`G_ema` + progress; **no optimizer state**) | `network-snapshot-latest.pt` (G, D, G_ema, both optimizers) | **none** (no resume) | `network-snapshot-latest.pt` (state, net, loss, optimizer, ema) |
+| inference history (pruned) | `network-snapshot-<kimg>-inference.pkl` — only with `--save-inference-only 1` | `network-snapshot-<kimg>-inference.pt` — always | `diffit-snapshot-<kimg>-inference.pt` — every snap tick **+ last tick**, atomic, EMA-only + `{n_classes, resolution, class_names, cur_nimg}` | `network-snapshot-<kimg>-<ema_std>.pkl` — always, one per EMA std |
+| best model | `best_model.pkl` | `best_model.pt` | **none** (pick post-hoc from `stats.jsonl`) | `best_model.pt` |
+| final artifact | — | — | **none** (last-tick snapshot *is* final) | — |
 | EMA | classic `G_ema` (rampup) | classic `g_ema` | classic EMA (`--ema-rate`) | **PowerFunctionEMA** (post-hoc reconstructable via `reconstruct_phema.py`) |
 
 ```{warning}
@@ -99,7 +114,7 @@ between repos.
 | available | `dpm++`, `unipc`, `ddim`, `ddpm` | `dpm++`, `edm` (Heun), `euler`, `ddim` (≡ `euler`) |
 | space | DDPM 1000-step discrete schedule | EDM σ-space (Karras schedule) |
 | eval default | `ddim` @ 100 steps | `dpm++` @ 25 steps |
-| flags | `--eval-sampler` / `--eval-sampling-steps` (training), `--sampler` / `--num-sampling-steps` (generation) | `--eval-sampler` / `--eval-sampling-steps` (training), `--sampler` / `--steps` (generation) |
+| flags | `--eval-sampler` / `--eval-sampling-steps` (training), `--sampler` / `--steps` (generation) | `--eval-sampler` / `--eval-sampling-steps` (training), `--sampler` / `--steps` (generation) |
 
 ```{note}
 The overlapping names are **not interchangeable**: `ddim` and `dpm++` integrate
@@ -113,10 +128,10 @@ compare-samplers tool ({doc}`sampler_comparison`).
 | | san-v2 | StyleSwin-v2 | DiffiT-v2 | EDM2-v2 |
 |---|---|---|---|---|
 | script | `gen_images.py` | `gen_images.py` | `diffit-gen-images` | `edm2-gen-images` |
-| checkpoint flag | `--network` (`.pkl`) | `--network` (`.pt`) | `--model-path` (`.pt`) | `--net` (`.pkl`) |
-| class selection | `--classes 0,1,2` + `--samples-per-class` | `--classes` + `--samples-per-class` | `--classes` + `--samples-per-class` (or `--seeds`) | **`--class <idx>` + `--seeds 0-999`** — one class per run |
-| output | **HDF5 (default)** or per-class PNG dirs (`--save-mode`) | per-class PNG dirs only | HDF5 shards → merged `.h5`, or dirs (`--save-mode`) | flat `<seed>.png` only |
-| quality knobs | `--trunc`, `--centroids-path` | `--trunc` | `--cfg-scale`, `--sampler`, `--num-sampling-steps` | `--sampler`, `--steps`, `--guidance --gnet` |
+| checkpoint flag | `--network` (`.pkl`) | `--network` (`.pt`) | `--network` (alias `--model-path`) (`.pt`) | `--net` (`.pkl`) |
+| class selection | `--classes 0,1,2` + `--samples-per-class` | `--classes` + `--samples-per-class` | `--classes` (indices **or names**) + `--samples-per-class` (or `--seeds`) | **`--class <idx>` + `--seeds 0-999`** — one class per run |
+| output | **HDF5 (default)** or per-class PNG dirs (`--save-mode`) | per-class PNG dirs only | HDF5 shards → merged `<desc>.h5` (unified sig), or dirs + `classes.json` (`--save-mode`) | flat `<seed>.png` only |
+| quality knobs | `--trunc`, `--centroids-path` | `--trunc` | `--cfg-scale`, `--sampler`, `--steps` | `--sampler`, `--steps`, `--guidance --gnet` |
 
 ```{warning}
 **The generation artifacts are not equivalent.** The downstream angle pipeline
@@ -150,11 +165,10 @@ model page and in the {doc}`models_api_proposal` label contract (§5).
 ## Other known divergences
 
 1. **combra install source differs per repo**: san-v2's `requirements.txt` uses
-   an editable local checkout (`-e ../wc_cv/combra`); EDM2-v2 and StyleSwin-v2
-   pull the private repo over `git+https` via the `[combra]` extra; DiffiT-v2
-   expects combra installed first from a local checkout.
-2. **StyleSwin-v2 has no `requirements.txt`** — dependencies live only in
-   `pyproject.toml` (`pip install -e .`), unlike the other three.
+   an editable local checkout (`-e ../wc_cv/combra`); EDM2-v2, StyleSwin-v2 and
+   **DiffiT-v2** pull the private repo over `git+https` via the `[combra]` extra.
+2. **StyleSwin-v2 and DiffiT-v2 have no `requirements.txt`** — dependencies live
+   only in `pyproject.toml` (`pip install -e .`), unlike san-v2 and EDM2-v2.
 3. **CUDA toolchain**: san-v2 compiles its ops against conda's `nvcc`
    (`CUDA_HOME=$CONDA_PREFIX`); StyleSwin-v2 uses the system module
    (`module load CUDA/13.1`). DiffiT-v2 and EDM2-v2 need no custom CUDA ops.


### PR DESCRIPTION
## Summary

Update documentation to reflect DiffiT-v2's implementation of the v2 model API convention, including changes to checkpoint scheme, training CLI, generation contract, dataset/label handling, and logging infrastructure.

## Key Changes

- **Checkpoint scheme**: Replace `--resume` with `--init-weights` for progressive finetuning; remove best/latest/final artifacts in favor of atomic EMA-only `diffit-snapshot-<kimg>-inference.pt` snapshots with embedded metadata (`n_classes`, `resolution`, `class_names`, `cur_nimg`). Runs are unrecoverable by design (no resume capability).

- **Training CLI**: Document `--precision {fp32,fp16,bf16}` flag, explicit boolean syntax (`--tf32 True`, `--bench True`, etc.), and clarify that total batch = `batch-gpu × gpus × grad-accum`.

- **Dataset/label contract**: Update `diffit-prepare-data` to use `convert` subcommand; document that `class_names` is written into `dataset.json`, flows into every checkpoint and generated `.h5`, and eliminates need for external `CLASS_MAP`. Grayscale images are converted to RGB at build time (not silently by loader). Class labels derive from alphabetical parent folder order, not filename prefixes.

- **Generation**: Rename `--model-path` to `--network` (with alias); change `--num-sampling-steps` to `--steps`; add `--batch-gpu` flag; support class **names** in `--classes` (validated against checkpoint metadata); default to HDF5 output with atomic shard merging to `<desc>.h5` (unified `format="generated_images_shard"` / `schema_version=1`); per-image seeding for reproducibility.

- **Evaluation**: Document `--num-fid-samples` and `--combra-ref-count` for controlling reference set size; clarify that combra reference is the whole training set by default (seeded random subset if capped). Add logging details: `stats.jsonl` scalar rows + TensorBoard namespaces (`Loss/*`, `LearningRate/*`, `Timing/*`, `Resources/*`, `Metrics/*`, `Fakes`).

- **Models API table**: Add DiffiT-v2 row documenting v2 convention compliance; update checkpoint/inference/EMA columns to reflect new scheme; clarify that legacy checkpoints lack `class_names` and require per-run `CLASS_MAP` lookup.

- **Sampler flags**: Correct DiffiT-v2 row to use `--sampler` / `--steps` (not `--num-sampling-steps`) for consistency with EDM2-v2.

- **Dependencies**: Note that DiffiT-v2 (like StyleSwin-v2) has no `requirements.txt`; dependencies live in `pyproject.toml` only.

## Notable Details

- Atomic checkpoint writes (temp file + `os.replace`) ensure on-disk snapshots are always complete.
- Last tick always snapshots, so newest snapshot is the final model.
- Class name validation and metadata embedding eliminate the index↔grain mapping ambiguity that plagued legacy runs.
- Progressive finetuning now uses EMA snapshots (weights only, fresh optimizer) rather than full checkpoints.

https://claude.ai/code/session_01Qp5fALTmubvXfqeDAZpT9M