### PR TITLE
docs: sync san-v2 pages with the v0.2.0 API-convention adoption

### DIFF
--- a/docs/examples/models_api.md
+++ b/docs/examples/models_api.md
@@ -3,26 +3,25 @@
 Four source-only repos generate WC-Co microstructure SEM images. They are
 **separate forks that deliberately converge on one "san-v2-style" tooling
 convention** — not a single package. This page is the cross-model map: what is
-identical everywhere (the contract), and where the repos still diverge.
+identical everywhere (the contract) and the few model-family details that stay
+per-repo (samplers, EMA, float training space).
 
 ```{seealso}
-This page documents the **current** state. A specification that unifies the
-remaining divergences — including per-repo migration deltas — is proposed in
-{doc}`models_api_proposal`.
+This page documents the **current** state. The full specification — including the
+per-repo migration deltas — is in {doc}`models_api_proposal`.
 ```
 
 ```{note}
-**DiffiT-v2 now implements the v2 convention** ({doc}`models_api_proposal` §12).
-Its checkpoint scheme (EMA-only `diffit-snapshot-<kimg>-inference.pt`, atomic,
-no resume/best/latest/final), training CLI (`--precision`, `True/False`
-booleans, `--init-weights`, `--mirror`), generation contract (`--network` /
-`--steps`, self-spawning `--gpus`, per-image seeds, unified
-`format="generated_images_shard"` / `schema_version=1` h5 merged to `<desc>.h5`),
-dataset/label contract (uint8 items, `class_names` in `dataset.json` /
-checkpoints / h5), logging (`stats.jsonl` scalar rows + §7 TensorBoard
-namespaces) and infrastructure (no Hydra, no `requirements.txt`, `sh/` launch
-scripts) all follow the spec. The DiffiT-v2 cells below reflect that; the other
-three repos still diverge as noted.
+**All four repos now implement the v2 convention** ({doc}`models_api_proposal`).
+san-v2 (v0.2.0), StyleSwin-v2, DiffiT-v2 and EDM2-v2 each expose the shared API:
+console scripts, the unified training CLI (`--precision`/`--tf32`/`--bench`,
+`True/False` booleans, kimg/tick progress), EMA-only `.pt` inference snapshots
+(atomic, no resume/best/latest/final), the unified HDF5 generation signature
+(`format="generated_images_shard"`, `schema_version=1`, merged `<desc>.h5`),
+`class_names` on every artifact, combra metrics mirrored into `stats.jsonl`, and
+no Hydra / `requirements.txt`. The cells below therefore read as the target API in
+every column; only the genuinely model-specific rows (samplers, EMA algorithm,
+float training space) still differ, and are documented as such.
 ```
 
 | repo | family | upstream | docs |
@@ -36,76 +35,68 @@ three repos still diverge as noted.
 
 Every repo follows the same conventions:
 
-- **click CLI as the single source of truth** for options and defaults; where a
-  Hydra wrapper exists (`train_hydra.py`), it introspects the click options and
-  calls the same launch path, so both entry points produce identical runs.
-- **Dataset format**: StyleGAN-style `.zip` of images + `dataset.json`
-  (`{"labels": [[path, classID], ...]}`), built with the repo's `dataset_tool*.py`.
+- **click CLI as the single source of truth** for options and defaults; the Hydra
+  wrappers have been removed everywhere.
+- **Dataset format**: StyleGAN-style `.zip` of images + `dataset.json`, which now
+  carries an index-aligned `class_names` list, built with the repo's
+  `<model>-prepare-data convert` tool.
 - **Run directories**: auto-numbered `<outdir>/<id:05d>-<cfg>-gpus<N>-batch<B>[-desc]`
-  with `training_options.json`, `log.txt`, `stats.jsonl`, TensorBoard events and
-  `fakes<kimg>.png` grids; training is accounted in **kimg/ticks** with `--snap`
+  with `training_options.json`, the rank-0 `.log`, `stats.jsonl`, TensorBoard events
+  and `fakes<kimg>.png` grids; training is accounted in **kimg/ticks** with `--snap`
   controlling the snapshot cadence.
-- **Multi-GPU is self-spawning**: training launches one worker per GPU via
-  `torch.multiprocessing` — no `torchrun` for training (some *generation* scripts
-  do use `torchrun`).
+- **Multi-GPU is self-spawning**: both training and generation launch one worker per
+  GPU via `torch.multiprocessing` — no `torchrun`.
 - **combra evaluation** (optional, guarded import, `--combra-metrics` default
   `true`): every snapshot tick, fakes are generated **sharded across all ranks**
-  and scored against the **whole training set** (reference features precomputed
-  once) using combra's split APIs — {py:func}`combra.metrics.fid_features` /
+  and scored against the training set (reference features precomputed once) using
+  combra's split APIs — {py:func}`combra.metrics.fid_features` /
   `fid_from_features`, the `cmmd_*` / `fd_dinov2_*` analogues, and
   {py:func}`combra.metrics.images_to_pooled_angles` +
   `angle_density_metrics_from_pooled` — numerically equivalent to a single-GPU
-  {py:func}`combra.metrics.compute_all_metrics` call. Results land in TensorBoard
-  as `Metrics/combra_fid10k`, `Metrics/combra_cmmd10k`,
-  `Metrics/combra_fd_dinov2_10k` + the angle metrics. DiffiT-v2 and EDM2-v2
-  also mirror them into `stats.jsonl`; **san-v2 and StyleSwin-v2 write them
-  to TensorBoard only** — the tfevents file is the sole record of those
-  runs' metric history.
-- **Best-model checkpoint** selected by `combra_fid10k`, plus a rolling full
-  `network-snapshot-latest.pt` overwritten in place and a history of small
-  inference snapshots, pruned to `--snapshot-keep-last` (default 3) —
-  except in **san-v2**, where no pruning exists and snapshots accumulate
-  unbounded, and **DiffiT-v2**, which has dropped resume/best/latest entirely
-  and keeps only the pruned EMA-only inference snapshots (§12).
+  {py:func}`combra.metrics.compute_all_metrics` call. Results are mirrored into
+  **both** TensorBoard (`Metrics/combra_fid10k`, `Metrics/combra_cmmd10k`,
+  `Metrics/combra_fd_dinov2_10k` + the angle metrics) and `stats.jsonl` in all
+  four repos, so post-hoc snapshot selection survives loss of the tfevents file.
+- **One checkpoint kind**: the EMA-only `.pt` inference snapshot, written
+  atomically every snapshot tick **and always at the last tick**, pruned to
+  `--snapshot-keep-last` (default 3, `0` = keep all). No resume, no rolling
+  `latest`, no `best_model.*`, no separate final artifact — the best snapshot is
+  chosen post-hoc from `stats.jsonl`.
 
 ## Training
 
 | | san-v2 | StyleSwin-v2 | DiffiT-v2 | EDM2-v2 |
 |---|---|---|---|---|
-| entry point | `train.py` | `train.py` | `scripts/train.py` (`diffit-train`) | `train_edm2.py` (`edm2-train`) |
-| Hydra wrapper | `train_hydra.py` | **none** | **none** (removed) | `train_hydra.py` |
-| presets | `--cfg` = architecture (`stylegan3-r`, …) | `--cfg styleswin-{256,512,1024}` | `--cfg diffit-{256,512,1024}` | `--preset edm2-img{256,512,1024}-s` (+ more sizes) |
-| required flags | `--outdir --cfg --data --gpus --batch-gpu` | `--outdir --data --gpus` | `--outdir --cfg --data --gpus --batch-gpu` | `--outdir --data` |
-| resolution strategy | **progressive**: 16² stem, then superres stages (`--superres --up_factor 2 --path_stem`) | independent run per resolution | finetune upward via `--init-weights` (RoPE-2D) | independent preset per resolution (shared VAE latent space) |
+| entry point | `san-train` | `styleswin-train` | `diffit-train` | `edm2-train` |
+| Hydra wrapper | **none** | **none** | **none** | **none** |
+| presets | `--cfg` = architecture (`stylegan3-r`, …) | `--cfg styleswin-{256,512,1024}` | `--cfg diffit-{256,512,1024}` | `--cfg edm2-img{256,512,1024}-s` (+ more sizes) |
+| required flags | `--outdir --cfg --data --gpus --batch-gpu` | `--outdir --data --gpus` | `--outdir --cfg --data --gpus --batch-gpu` | `--outdir --data` (`--cfg`/`--gpus`/`--batch-gpu` default) |
+| precision | `--precision {fp32,fp16,bf16}` + `--tf32`/`--bench` (unified across all four; per-repo default) | | | |
+| resolution strategy | **progressive**: 16² stem, then superres stages (`--superres --up-factor 2 --path-stem`, a weights-only warm start) | independent run per resolution | finetune upward via `--init-weights` (RoPE-2D) | independent preset per resolution (shared VAE latent space); no resume |
 
 ## Evaluation
 
 | | san-v2 | StyleSwin-v2 | DiffiT-v2 | EDM2-v2 |
 |---|---|---|---|---|
-| in-training combra | ✔ (10 000 fakes, fixed) | ✔ (10 000 fakes, fixed) | ✔ (fakes match the whole-dataset reference) | ✔ (`--num-fid-samples`, default 10 000; `--combra-ref-count` caps the reference) |
-| native metric suite | `--metrics` registry (`fid50k_full`, `is50k`, …) | none (`--metrics` is a reserved stub) | Inception IS/FID/sFID/P/R via `--combra-metrics=false` | offline FID + FD-DINOv2 |
-| standalone evaluator | `calc_metrics.py` | **none** | `diffit-eval` | `edm2-eval calc/gen/ref` |
+| in-training combra | ✔ (`--num-fid-samples`, default 10 000; `--combra-ref-count` caps the reference) | ✔ (`--num-fid-samples` / `--combra-ref-count`) | ✔ (`--num-fid-samples` / `--combra-ref-count`) | ✔ (`--num-fid-samples` / `--combra-ref-count`) |
+| native metric suite | `--metrics` registry (legacy) | none (`--metrics` is a reserved stub) | Inception IS/FID/sFID/P/R via `--combra-metrics=false` | offline FID + FD-DINOv2 |
+| standalone evaluator | `san-eval` | `styleswin-eval` | `diffit-eval` | `edm2-eval calc/gen/ref` |
 | sampler-vs-steps sweep | n/a (GAN) | n/a (GAN) | `diffit-compare-samplers` | `edm2-compare-samplers` (see {doc}`sampler_comparison`) |
 
 ## Checkpoints
 
+The checkpoint contract is now identical across all four (EMA-only `.pt` state
+dicts, atomic, pruned, no resume/best/latest/final); only the snapshot filename
+prefix and the EMA algorithm differ.
+
 | | san-v2 | StyleSwin-v2 | DiffiT-v2 | EDM2-v2 |
 |---|---|---|---|---|
-| format | **pickled modules** (`.pkl`, loaded via `legacy.py`) | `.pt` state dicts | `.pt` state dicts (EMA-only + metadata) | mixed: inference `.pkl` + resume `.pt` |
-| rolling full checkpoint | `network-snapshot-latest.pt` (`G`/`D`/`G_ema` + progress; **no optimizer state**) | `network-snapshot-latest.pt` (G, D, G_ema, both optimizers) | **none** (no resume) | `network-snapshot-latest.pt` (state, net, loss, optimizer, ema) |
-| inference history (pruned) | `network-snapshot-<kimg>-inference.pkl` — only with `--save-inference-only 1` | `network-snapshot-<kimg>-inference.pt` — always | `diffit-snapshot-<kimg>-inference.pt` — every snap tick **+ last tick**, atomic, EMA-only + `{n_classes, resolution, class_names, cur_nimg}` | `network-snapshot-<kimg>-<ema_std>.pkl` — always, one per EMA std |
-| best model | `best_model.pkl` | `best_model.pt` | **none** (pick post-hoc from `stats.jsonl`) | `best_model.pt` |
-| final artifact | — | — | **none** (last-tick snapshot *is* final) | — |
-| EMA | classic `G_ema` (rampup) | classic `g_ema` | classic EMA (`--ema-rate`) | **PowerFunctionEMA** (post-hoc reconstructable via `reconstruct_phema.py`) |
-
-```{warning}
-**`--save-inference-only` means opposite things.** In DiffiT-v2, EDM2-v2 and
-StyleSwin-v2, inference snapshots are always written and the flag **skips** the
-rolling full `network-snapshot-latest.pt`. In **san-v2** the rolling full
-checkpoint is written regardless, and `--save-inference-only 1` **adds** the
-per-tick inference `.pkl`s. Check the model's own page before copying the flag
-between repos.
-```
+| format | **`.pt` state dicts** — EMA-only + `{n_classes, resolution, class_names, cur_nimg}` metadata, atomic writes, no pickled modules | same | same | same |
+| rolling full checkpoint | **none** (no resume) | **none** | **none** | **none** |
+| inference snapshot (pruned) | `san-snapshot-<kimg>-inference.pt` — every tick **+ last tick**, `--snapshot-keep-last` | `network-snapshot-<kimg>-inference.pt` | `diffit-snapshot-<kimg>-inference.pt` | `edm2-snapshot-<kimg>[-<ema_std>]-inference.pt` |
+| best model | **none** (post-hoc from `stats.jsonl`) | **none** | **none** | **none** |
+| final artifact | **none** (newest snapshot is final) | **none** | **none** | **none** |
+| EMA | classic `G_ema` (rampup) | classic `g_ema` | classic EMA (`--ema-rate`) | **PowerFunctionEMA** (one snapshot per EMA std) |
 
 ## Samplers (diffusion models only)
 
@@ -127,51 +118,52 @@ compare-samplers tool ({doc}`sampler_comparison`).
 
 | | san-v2 | StyleSwin-v2 | DiffiT-v2 | EDM2-v2 |
 |---|---|---|---|---|
-| script | `gen_images.py` | `gen_images.py` | `diffit-gen-images` | `edm2-gen-images` |
-| checkpoint flag | `--network` (`.pkl`) | `--network` (`.pt`) | `--network` (alias `--model-path`) (`.pt`) | `--net` (`.pkl`) |
-| class selection | `--classes 0,1,2` + `--samples-per-class` | `--classes` + `--samples-per-class` | `--classes` (indices **or names**) + `--samples-per-class` (or `--seeds`) | **`--class <idx>` + `--seeds 0-999`** — one class per run |
-| output | **HDF5 (default)** or per-class PNG dirs (`--save-mode`) | per-class PNG dirs only | HDF5 shards → merged `<desc>.h5` (unified sig), or dirs + `classes.json` (`--save-mode`) | flat `<seed>.png` only |
+| script | `san-gen-images` | `styleswin-gen-images` | `diffit-gen-images` | `edm2-gen-images` |
+| checkpoint flag | `--network` (`.pt`) | `--network` (`.pt`) | `--network` (alias `--model-path`) (`.pt`) | `--net`/`--network` (`.pt`) |
+| class selection | `--classes` (indices/ranges **or names**, validated) + `--samples-per-class` | same | same | `--classes 0,1,4-6` **or names** + `--samples-per-class` (`--seeds` legacy) |
+| output | **HDF5** (unified sig, merged `<desc>.h5`, merge hard-fails on gaps) or PNG dirs + `classes.json` (`--save-mode`); self-spawning `--gpus` | same | same | same |
 | quality knobs | `--trunc`, `--centroids-path` | `--trunc` | `--cfg-scale`, `--sampler`, `--steps` | `--sampler`, `--steps`, `--guidance --gnet` |
 
-```{warning}
-**The generation artifacts are not equivalent.** The downstream angle pipeline
-(`co_angles/generate_class_samples.py`, {py:meth}`combra.data.PobeditDataset.generate_angles`)
-consumes the per-class HDF5 layout of san-v2's `RankH5Writer`, which DiffiT-v2
-replicates. **StyleSwin-v2 and EDM2-v2 emit PNGs only** — their outputs need a
-conversion step before entering that pipeline.
+```{note}
+**The generation artifacts are now equivalent.** All four repos emit the per-class
+`RankH5Writer` HDF5 layout (`class_<c>/images|seeds`, uint8 NHWC) with the unified
+`format="generated_images_shard"` / `schema_version=1` signature and `class_names`,
+merged to `<desc>.h5` — directly consumable by the downstream angle pipeline
+(`co_angles/generate_class_samples.py`,
+{py:meth}`combra.data.PobeditDataset.generate_angles`) with no conversion step, and
+the merge hard-fails on incomplete shards.
 ```
 
 ## Class index → grain class
 
-The mapping is a property of the **zip a run trained on**, not of the repo:
-the zips store only integer labels, every repo takes them **verbatim** at
-train time, and no artifact records the `Ultra_Co*` names. The dataset
-*tools* differ — san-v2's copies labels from a source `dataset.json` written
-in the non-alphabetical order `0 → Ultra_Co25`, `1 → Ultra_Co11`,
-`2 → Ultra_Co6_2`, while the others' derive them from the alphabetical
-folder sort (`0 → Ultra_Co11`, `1 → Ultra_Co25`) — but the on-disk
-`imagenet_9to4_*` archives that the real DiffiT-v2 and StyleSwin-v2 runs
-consumed carry the **same swapped order as the san-v2 zips**.
+All four dataset tools now derive the integer label from the **alphabetical** class
+folder sort (`0 → Ultra_Co11`, `1 → Ultra_Co25`, `2 → Ultra_Co6_2`) and stamp an
+index-aligned `class_names` list into `dataset.json`, every checkpoint and every
+generated artifact — so new runs are self-describing by name and combra matches by
+name rather than a fragile integer convention.
 
 ```{warning}
-The existing checkpoints of all four models therefore most likely share
-san-v2's swapped convention. Before comparing across models or remapping
-with combra's `CLASS_MAP`, classify each run by the dataset path in its
-`training_options.json` — remapping a checkpoint that already uses san-v2's
-order introduces the very swap the remap is meant to fix. Details on each
-model page and in the {doc}`models_api_proposal` label contract (§5).
+**Existing pre-migration checkpoints still use the old swapped order.** The on-disk
+`imagenet_9to4_*` archives the existing runs of all four models trained on carry the
+non-alphabetical order `0 → Ultra_Co25`, `1 → Ultra_Co11`, `2 → Ultra_Co6_2` (the
+`Co11`↔`Co25` swap) and record no `class_names`. Those checkpoints and everything
+generated from them stay under combra's legacy `CLASS_MAP` until retrained on rebuilt
+zips — classify each run by the dataset path in its `training_options.json` before
+remapping. See the {doc}`models_api_proposal` label contract (§5).
 ```
 
 ## Other known divergences
 
-1. **combra install source differs per repo**: san-v2's `requirements.txt` uses
-   an editable local checkout (`-e ../wc_cv/combra`); EDM2-v2, StyleSwin-v2 and
-   **DiffiT-v2** pull the private repo over `git+https` via the `[combra]` extra.
-2. **StyleSwin-v2 and DiffiT-v2 have no `requirements.txt`** — dependencies live
-   only in `pyproject.toml` (`pip install -e .`), unlike san-v2 and EDM2-v2.
-3. **CUDA toolchain**: san-v2 compiles its ops against conda's `nvcc`
-   (`CUDA_HOME=$CONDA_PREFIX`); StyleSwin-v2 uses the system module
-   (`module load CUDA/13.1`). DiffiT-v2 and EDM2-v2 need no custom CUDA ops.
-4. **combra eval sample count** is configurable only in EDM2-v2
-   (`--num-fid-samples`); the other three use a fixed 10 000. Cross-model
-   `combra_fid10k` comparisons are valid only at the default count.
+Now that all four repos share the contract, the remaining differences are
+model-family details, not tooling drift:
+
+1. **combra install** is uniform: all four pull the private repo over `git+https`
+   via the `[combra]` extra, and none ship a `requirements.txt` (`pip install -e .`).
+2. **CUDA toolchain**: san-v2 and StyleSwin-v2 build custom CUDA ops (san-v2 against
+   conda's `nvcc` with `CUDA_HOME=$CONDA_PREFIX`; StyleSwin-v2 via the system CUDA
+   module); DiffiT-v2 and EDM2-v2 are pure-torch and need no custom ops.
+3. **Model-family internals stay per-repo** (documented, not unified): the samplers
+   (above), the EMA algorithm (classic half-life vs `--ema-rate` vs PowerFunctionEMA),
+   and the float training space (`[-1, 1]` for san-v2/DiffiT-v2, ImageNet mean/std for
+   StyleSwin-v2, the VAE latent space for EDM2-v2). Every artifact still crosses the
+   boundary as uint8, so cross-repo comparisons remain valid.

--- a/docs/examples/models_api_proposal.md
+++ b/docs/examples/models_api_proposal.md
@@ -1,11 +1,12 @@
 # Generative models — proposed standard API ("v2 convention")
 
 ```{note}
-**Status: proposal.** Nothing here is implemented yet — the **current** state
-of each repo (including where they diverge) is documented in
-{doc}`models_api`. This page has two parts: **Part 1** specifies the target
-API every repo exposes; **Part 2** lists the changes each repo needs to get
-there.
+**Status: implemented.** All four repos — san-v2 (v0.2.0), StyleSwin-v2,
+DiffiT-v2 and EDM2-v2 — now expose the Part 1 API; the converged current state is
+documented in {doc}`models_api`. This page is retained as the specification of
+record: **Part 1** specifies the target API every repo exposes; **Part 2** lists
+the per-repo deltas that got each there (and the dataset-rebuild rails that remain
+before the legacy `CLASS_MAP` warnings can be dropped).
 ```
 
 The goal: any command, flag, checkpoint name, or generated artifact learned on

--- a/docs/examples/san_v2.md
+++ b/docs/examples/san_v2.md
@@ -2,21 +2,23 @@
 
 [**san-v2**](https://github.com/dkagramanyan/san-v2) is a fork of Sony's
 StyleSAN-XL (Slicing Adversarial Network, StyleGAN3 + Projected GAN) used to
-generate WC-Co microstructure SEM images. Its training evaluation is wired into
-combra: on every **snapshot** tick it scores generated samples with combra's
-sharded split-API metrics (numerically equivalent to
-{py:func}`combra.metrics.compute_all_metrics`) and logs the results to TensorBoard.
+generate WC-Co microstructure SEM images. As of **v0.2.0** it implements the v2
+model API convention specified in {doc}`models_api_proposal` (§12); this page
+documents that API. On every **snapshot** tick it scores generated samples with
+combra's sharded split-API metrics (numerically equivalent to
+{py:func}`combra.metrics.compute_all_metrics`) and logs the results to both
+TensorBoard and `stats.jsonl`.
 
-The combra integration is **optional** and controlled by its own flag,
-`--combra-metrics` (default `true`) — **independent of `--metrics`**, so you can run
-combra with `--metrics none` (skip FID) or vice-versa. san-v2 does not depend on
-combra: the import is guarded, so training runs unchanged when combra is not
-installed — but if `--combra-metrics=true` and the package is missing, training emits
-a **warning** at startup (and skips the metrics) so it is never silently ignored. To
-enable the metrics, install combra alongside san-v2:
+The combra integration is **optional** and controlled by `--combra-metrics`
+(default `True`). san-v2 does not depend on combra: the import is guarded, so
+training runs unchanged when combra is not installed — but if
+`--combra-metrics=True` and the package is missing, training emits a **warning**
+at startup (and skips the metrics) so it is never silently ignored. To enable the
+metrics, install the optional extra (pulled from the private repo over
+`git+https`):
 
 ```bash
-pip install combra            # or: pip install 'san-v2[combra]'
+pip install 'san-v2[combra]'
 ```
 
 The full **install → test → train → generate** guide lives in the san-v2
@@ -24,170 +26,149 @@ The full **install → test → train → generate** guide lives in the san-v2
 
 ## Installation
 
-Create a `python=3.12` conda env, install the latest PyTorch (CUDA 13.2 wheels), the
-CUDA compiler (`nvcc`) and ninja **from conda** (both needed to build the custom CUDA
-ops — a pip ninja conflicts with conda's, and the torch wheel ships no `nvcc`), then the
-remaining deps. torch and ninja are intentionally kept out of `requirements.txt` so the
-last step won't disturb them:
+`pyproject.toml` is the only dependency declaration (there is no
+`requirements.txt`) and `pip install -e .` is the one install path. Create a conda
+env, install the latest PyTorch (CUDA wheels), the CUDA compiler (`nvcc`) and
+ninja **from conda** (both needed to build the custom CUDA ops — a pip ninja
+conflicts with conda's, and the torch wheel ships no `nvcc`), then the package.
+torch and ninja are intentionally kept out of `pyproject.toml` so the last step
+won't disturb them:
 
 ```bash
-conda create -n san python=3.12 -y && conda activate san
+conda create -n san-v2 python=3.12 -y && conda activate san-v2
 pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cu132
 conda install -c nvidia cuda-nvcc -y     # match torch's CUDA major (13.x)
 conda install anaconda::ninja -y
-pip install -r requirements.txt          # from the san-v2 repo root
+pip install -e ".[combra]"               # from the san-v2 repo root; drop [combra] to skip metrics
 ```
 
-The `sbatch/` scripts load no system CUDA module — they set `CUDA_HOME=$CONDA_PREFIX`
-so the ops compile against this conda toolkit.
+Installing the package exposes four console scripts: **`san-train`**,
+**`san-gen-images`**, **`san-eval`**, **`san-prepare-data`**. The `sh/` launch
+scripts set `CUDA_HOME=$CONDA_PREFIX` so the ops compile against this conda
+toolkit, and set `HF_HUB_OFFLINE=1` / `TRANSFORMERS_OFFLINE=1` for offline compute
+nodes (prefetch backbones once on a login node with `bash download_models.sh`).
 
 ## Test the build
 
 The custom CUDA ops are JIT-compiled on first use. Compile and check them (including
-the H200 `sm_90` path) before training, and run the CPU SAN-layer unit tests:
+the H200 `sm_90` path) before training, and run the CPU tests (CLI-contract smoke
+tests + SAN-layer unit tests):
 
 ```bash
 python tests/test_cuda_ops.py    # CUDA-op compile + correctness check (needs a GPU)
-python -m pytest tests/ -v       # SAN-layer unit tests (CI; GPU tests auto-skip on CPU)
+python -m pytest tests/ -v       # CPU smoke + SAN-layer unit tests (GPU tests auto-skip)
+```
+
+## Dataset preparation
+
+`san-prepare-data` is a click group; its `convert` subcommand builds a
+StyleGAN-style zip from a folder of class subfolders. Labels are derived from the
+**alphabetical** order of the class-folder names, an index-aligned `class_names`
+list is written into `dataset.json`, and grayscale sources are converted to RGB at
+build time. A single unlabeled image in an otherwise-labeled tree is a hard error
+(never a silent drop of the whole label set):
+
+```bash
+san-prepare-data convert --source ./raw/wc_co --dest ./datasets/wc_co_256.zip \
+    --transform center-crop --resolution 256x256
 ```
 
 ## Training
 
-Models are trained **progressively** (low → high resolution), each stage resuming
-from the previous stage's `best_model.pkl`. The 16² stem trains from scratch; every
-higher resolution is a super-resolution stage (`--superres --up_factor 2`):
+Models are trained **progressively** (low → high resolution). The 16² stem trains
+from scratch; every higher resolution is a super-resolution stage that
+**weights-only warm-starts** from the previous stage's inference snapshot via
+`--path-stem` (there is no resume — runs go start-to-finish):
 
 ```bash
 # Stage 0 — 16x16 stem
-python train.py --outdir=./runs/wc-cv_h200 --cfg=stylegan3-r --cond True \
-        --data=./datasets/imagenet_9to4_1024x1024_16x16.zip \
-        --gpus=2 --mirror=0 --snap 500 --batch-gpu 320 --kimg 20000 --syn_layers 6
+san-train --outdir ./runs --cfg stylegan3-r --cond True \
+    --data ./datasets/wc_co_16x16.zip \
+    --gpus 2 --mirror False --snap 500 --batch-gpu 320 --kimg 20000 --syn-layers 6
 
-# Stage N — superres, resuming from the previous stage
-python train.py --outdir=./runs/wc-cv_h200 --cfg=stylegan3-r --cond True \
-        --data=./datasets/imagenet_9to4_1024x1024_32x32.zip \
-        --gpus=2 --mirror=0 --snap 100 --batch-gpu 96 --kimg 20000 --syn_layers 6 \
-        --superres --up_factor 2 --head_layers 7 \
-        --path_stem ./runs/wc-cv_h200/00000-.../best_model.pkl
+# Stage N — superres, warm-starting from the previous stage's snapshot
+san-train --outdir ./runs --cfg stylegan3-r --cond True \
+    --data ./datasets/wc_co_32x32.zip \
+    --gpus 2 --mirror False --snap 100 --batch-gpu 96 --kimg 20000 --syn-layers 6 \
+    --superres --up-factor 2 --head-layers 7 \
+    --path-stem ./runs/00000-stylegan3-r-gpus2-batch640/san-snapshot-020000-inference.pt
 ```
 
-On the cluster the per-stage scripts in `sbatch/` are submitted from the sbatch folder
-onto the `rocky` partition (2× H200 each):
+Ready-made per-resolution launch scripts live in `sh/` (`train_256.sh`,
+`generate_512.sh`, …); they carry only the compute-node environment plus one
+console-command call, with SLURM specifics supplied at submission time:
 
 ```bash
-cd sbatch
-sbatch train_16x16.sbatch        # … through train_1024x1024.sbatch
+DATA=./datasets/wc_co_256.zip GPUS=2 bash sh/train_256.sh
+sbatch --account=<proj> --partition=rocky --gpus=2 sh/train_256.sh   # same script on a cluster
 ```
 
-Training can also be launched via Hydra (`train_hydra.py`), which shares the same
-`build_config()` logic as the click CLI. Because the click CLI is the single source of
-truth for defaults, any flag below works as a Hydra override too (e.g.
-`save_inference_only=true`).
+### Checkpoint scheme
 
-The production `sbatch/train_*.sbatch` scripts pass `--save-inference-only 0`, so a prod
-run keeps only the single full checkpoint `network-snapshot-latest.pt` — one big file
-**overwritten in place** every snapshot tick (it never accumulates), holding `G`/`D`/`G_ema`
-plus resume `progress` for `--resume` — together with the best-FID `best_model.pkl`. It
-does **not** accumulate per-tick artifacts. Pass `--save-inference-only 1` to also write a
-small `network-snapshot-<kimg>-inference.pkl` each tick holding **only `G_ema`** (no
-discriminator, no resume state) — the smallest artifact, exactly what `gen_images.py` and
-the combra evaluation consume — or `--save-weights-only 1`
-for per-tick `G`/`D`/`G_ema` when the discriminator is needed.
+There is exactly one artifact kind: an **EMA-only inference snapshot**
+`san-snapshot-<kimg:06d>-inference.pt`, a `.pt` **state dict** (no pickled
+modules — loading never depends on the `timm` version that trained the
+discriminator). It is written **atomically** every snapshot tick **and always at
+the last tick**, so the newest snapshot *is* the final model, and the history is
+pruned to `--snapshot-keep-last` (default 3, `0` = keep all). Each snapshot carries
+self-describing metadata `{n_classes, resolution, class_names, cur_nimg}`.
+
+There is **no resume, no `best_model`, no rolling `latest` checkpoint** — pick the
+best snapshot post-hoc from `stats.jsonl` (the combra metrics are mirrored there,
+not TensorBoard-only). Size `--kimg` (or split stages) so a run fits its job's time
+limit; an interrupted run cannot be continued.
 
 ```{warning}
-`--save-inference-only` means the **opposite** here than in the other three
-models: in san-v2 the rolling full `network-snapshot-latest.pt` is written
-regardless and `1` *adds* the per-tick inference `.pkl`s, whereas in
-{doc}`DiffiT-v2 <diffit>`, {doc}`EDM2-v2 <edm2>` and {doc}`StyleSwin-v2 <styleswin>`
-inference snapshots are always written and the flag *skips* the rolling full
-checkpoint. See the {doc}`API scheme <models_api>` before copying the flag
-between repos.
+This is a **breaking change** from pre-0.2.0 san-v2: `.pkl` artifacts,
+`--resume`, `best_model.pkl`, `--save-inference-only`/`--save-weights-only`,
+`--fp32`/`--nobench`, the `--metrics` registry and the Hydra entry point are all
+gone. Precision is now `--precision {fp32,fp16,bf16}` with `--tf32`/`--bench`;
+`--mirror` is a stochastic loader-level flip (no longer dataset x-flip doubling).
 ```
 
-```{note}
-Checkpoints that embed the projected discriminator's `timm` feature networks
-(`best_model.pkl` stems, `network-snapshot-latest.pt`) are `timm`-version-sensitive.
-`san-v2` now uses **timm 1.x**; stems saved under the old `timm==0.4.12` pin will not
-unpickle and must be regenerated. The inference-only `G_ema` snapshots carry no `timm`
-modules and are unaffected.
-```
+### combra metrics during training
 
-During training, the combra metrics use the **whole training set** as the fixed
-reference, scored against a fixed **`COMBRA_NUM_GEN = 10 000`** images generated
-from `G_ema` (their labels sampled from the training-set class distribution, seeded
-identically on every rank). combra's image-feature metrics estimate per-side
-statistics, so the two counts need not match. The reference set is fixed across
-training, so its features (pooled angles, FID/DINOv2 `(mu, sigma)`, CLIP embedding)
-are extracted **once before the training loop** — sharded across ranks (each rank
-processes its deterministic slice of the reals) and gathered to rank 0 — then
-cached; only the generated side is recomputed each evaluation tick.
+Each snapshot tick scores `--num-fid-samples` fakes (default 10 000, `0` disables
+eval) generated from `G_ema` against the training set as the fixed reference
+(cap it to a seeded random subset with `--combra-ref-count`). The reference
+features (pooled angles, FID/DINOv2 `(mu, sigma)`, CLIP embedding) are extracted
+**once before the loop**, sharded across ranks and cached; only the generated side
+recomputes each tick. Both the image-feature metrics (`fid`, `cmmd`, `fd_dinov2`)
+and the angle-density metrics (Wasserstein `w1`/`w2`/`circular_*` + bimodal-Gaussian
+fit errors) are logged under `Metrics/combra_*` in TensorBoard **and** `stats.jsonl`;
+the three image metrics carry their 10k sample size literally in the key
+(`combra_fid10k`, `combra_cmmd10k`, `combra_fd_dinov2_10k`).
 
-This mirrors the standard StyleGAN `fid50k_full` (all reals vs a fixed sample of
-fakes) but with a 10 000-image generated side, and it adds the angle-distribution
-and CMMD/FD-DINOv2 metrics on top of FID.
+`G_ema` emits float images in `[-1, 1]`; the loop denormalizes fakes to `uint8`
+with the single normalize/denormalize pair (asserted to round-trip) so reals and
+fakes are scored on the identical `uint8` scale.
 
-`G_ema` emits float images in `[-1, 1]`, while the reals are `uint8` `[0, 255]`;
-the loop denormalizes the fakes to `uint8` first so both sides are scored
-explicitly on the same scale. (combra also rescales float inputs internally — both
-the image-feature and the angle-density metrics map `[-1, 1]`/`[0, 1]` to `uint8`
-the same way — but denormalizing in the loop keeps the comparison unambiguous.)
-Each tick computes **both** the angle-density metrics (Wasserstein `w1`, `w2`,
-`circular_w1`, `circular_w2` and the bimodal-Gaussian `mu/sigma/amp` errors) **and**
-the image-feature metrics `fid`, `cmmd`, `fd_dinov2`. All are logged to TensorBoard
-under `Metrics/combra_*` and printed to the run log; the three image-feature metrics
-carry their 10k sample size in the key (`combra_fid10k`, `combra_cmmd10k`,
-`combra_fd_dinov2_10k`).
-
-On a **multi-GPU** run **all** the per-image extraction is **sharded across ranks** —
-both the image-feature metrics and the angle-density / Gaussian-fit metrics. Each
-rank generates its own shard of the fakes and, from that shard, extracts the CLIP /
-DINOv2 / InceptionV3 features and pools the vertex angles; the feature rows and the
-pooled-angle arrays are gathered to rank 0, where the Fréchet / MMD distances and
-the angle Wasserstein / Gaussian metrics are taken against the precomputed
-reference. This uses combra's split APIs — the feature halves
+On a **multi-GPU** run **all** per-image extraction is **sharded across ranks** —
+each rank generates its shard of the fakes, extracts the CLIP / DINOv2 / InceptionV3
+features and pools the vertex angles; the feature rows and pooled-angle arrays are
+gathered to rank 0, which takes the Fréchet / MMD distances and the angle metrics
+against the cached reference. This uses combra's split APIs — the feature halves
 ({py:func}`combra.metrics.fid_features` + {py:func}`combra.metrics.fid_from_features`,
 and the `cmmd_*` / `fd_dinov2_*` analogues) and the angle halves
 ({py:func}`combra.metrics.images_to_pooled_angles` +
 `angle_density_metrics_from_pooled`) — and is numerically identical to the
-single-GPU `compute_all_metrics(image_metrics=True)` path. Sharding the angle
-extraction also fixes a multi-GPU hang: when it ran rank-0-only over the full
-gathered batch, at 512/1024 px it could exceed NCCL's collective-timeout watchdog
-while the other ranks idled, aborting the job. On a single GPU the three image
-metrics instead run concurrently in a thread pool. Any whose optional backend is
-unavailable (e.g. no network to fetch the DINOv2/CLIP weights on an offline compute
-node) is recorded as `nan` rather than aborting — the angle metrics always come back. To
-avoid those `nan`s, pre-download the weights once on a login node with
-`bash download_models.sh` (or `python tests/test_san_modules.py`); the weights cache
-under `$HOME`, shared with the compute nodes.
-
-When `--combra-metrics` is enabled (the default), `fid50k_full` is dropped from
-`--metrics` so the expensive 50k-image FID pass is not computed twice, and
-`combra_fid10k` becomes the FID that drives best-model checkpoint selection
-(`best_model.pkl`).
-
-```{note}
-Because the reference is the entire dataset and an equal number of fakes is
-generated each evaluation tick, both the reference and the generated extraction
-(angle pooling + the InceptionV3 / CLIP / DINOv2 backbones) run on every rank over
-its own shard, so that cost is shared across GPUs; only the small gathered feature
-rows and pooled-angle arrays land on rank 0 for the final distances. Each snapshot
-still costs more than a full FID pass. For very large or high-resolution datasets this is
-memory- and compute-intensive; pass `--combra-metrics False` on runs where you
-don't want it.
-```
+single-GPU `compute_all_metrics(image_metrics=True)` path. Any metric whose optional
+backend is unavailable (e.g. no network to fetch DINOv2/CLIP weights) is recorded as
+`nan` rather than aborting. Pre-download the weights once on a login node with
+`bash download_models.sh`.
 
 ## Evaluation
 
-Standalone metrics for a trained checkpoint use the StyleGAN-XL runners:
+Standalone metrics for a trained snapshot use `san-eval` (the native metric
+registry is legacy; `--data` is required since snapshots carry no dataset kwargs):
 
 ```bash
-python calc_metrics.py --metrics=fid50k_full --network=<path_to_checkpoint>
-python calc_metrics.py --metrics=is50k       --network=<path_to_checkpoint>
+san-eval --metrics fid50k_full --data ./datasets/wc_co_256.zip \
+    --network ./runs/00001-stylegan3-r-gpus2-batch168/san-snapshot-020000-inference.pt
 ```
 
-To score arbitrary real/generated image batches with the combra metrics directly
-(the same ones logged during training), call
-{py:func}`combra.metrics.compute_all_metrics`:
+To score arbitrary real/generated image batches with the combra metrics directly,
+call {py:func}`combra.metrics.compute_all_metrics`:
 
 ```python
 >>> from combra.metrics import compute_all_metrics
@@ -198,74 +179,56 @@ To score arbitrary real/generated image batches with the combra metrics directly
  'fid': ..., 'cmmd': ..., 'fd_dinov2': ...}
 ```
 
-`image_metrics=True` is what adds the `fid`/`cmmd`/`fd_dinov2` keys (and is what the
-training loop passes); without it, only the angle-Wasserstein and bimodal-Gaussian
-metrics come back. Batches may be numpy arrays or torch tensors in `NCHW`/`NHWC`,
-with pixel values in `uint8`, `[0, 1]`, or `[-1, 1]`; combra rescales each side to
-`uint8` by inferring the range (any negative ⇒ `[-1, 1]`, else max ≤ 1 ⇒ `[0, 1]`).
-Because
-that inference is per-batch, prefer passing `uint8` (or an explicit, consistent
-scale) when you can — as the training loop does — so an unusual batch (e.g. a
-generated batch that happens to be all-positive) cannot be misread.
+Prefer passing `uint8` batches (as the training loop does) so an unusual batch
+(e.g. an all-positive `[-1, 1]` batch) cannot be misread by combra's range
+inference.
 
 ## Inference
 
-Generate samples from a trained network with `gen_images.py`. Images are written
-per class into `class_<id>/<class>_<index>.png`; pass `--gpus` (or launch with
-`torchrun`) to distribute generation:
+Generate samples from a trained snapshot with `san-gen-images`. `--gpus N`
+self-spawns one worker per GPU (the same launch model as training; no `torchrun`).
+`--classes` accepts indices, ranges, **or grain-class names**, validated against
+the checkpoint's `class_names` metadata:
 
 ```bash
-python gen_images.py \
-  --outdir=./generated/ \
-  --trunc=0.7 \
-  --samples-per-class 1000 \
-  --classes 0,1,2 \
-  --gpus 2 \
-  --batch-gpu 60 \
-  --network=<path_to_checkpoint>
+san-gen-images \
+    --network ./runs/00001-stylegan3-r-gpus2-batch168/san-snapshot-020000-inference.pt \
+    --outdir ./generated \
+    --classes Ultra_Co11,Ultra_Co6_2 \
+    --samples-per-class 1000 \
+    --gpus 2 --batch-gpu 60 --trunc 0.7 --save-mode hdf5
 ```
+
+With `--save-mode hdf5` (default) each rank writes a shard in the `RankH5Writer`
+layout (`class_<c>/images|seeds`, uint8 NHWC), merged by rank 0 into
+`<outdir>/<desc>.h5` — exactly what the wc_cv angle pipeline consumes. Every shard
+and the merged file carry `format="generated_images_shard"`, `schema_version=1` and
+the `class_names`, and the merge **hard-fails** if any sample slot is missing (a
+crashed run never feeds zero-filled black images downstream). `--save-mode dir`
+writes `class_<c>/idx_<i>_seed_<s>.png` plus a `classes.json` manifest. Generation
+is deterministic: `seed = base + class·samples_per_class + idx`.
 
 ### Class index → grain class
 
-The `--classes` integer selects a grain morphology. For the SAN model trained on the
-WC-Co dataset the indices map as:
+New zips built by `san-prepare-data` derive labels **alphabetically** and stamp
+`class_names` into the artifact, so downstream code matches by name and the mapping
+is self-describing:
 
 | index | grain class | morphology |
 |---|---|---|
-| `0` | `Ultra_Co25` | medium grain (средние зёрна) |
-| `1` | `Ultra_Co11` | small grain (мелкие зёрна) |
+| `0` | `Ultra_Co11` | small grain (мелкие зёрна) |
+| `1` | `Ultra_Co25` | medium grain (средние зёрна) |
 | `2` | `Ultra_Co6_2` | large grain (крупные зёрна) |
 
 ```{warning}
-**The other generators most likely share this order, not the alphabetical
-one.** The other repos' dataset *tools* nominally derive labels
-alphabetically (`0 → Ultra_Co11`, `1 → Ultra_Co25` — indices 0 and 1 swapped
-relative to SAN; `2 → Ultra_Co6_2` matches), but the on-disk
-`imagenet_9to4_*` archives their real runs consumed carry the **same swapped
-order as the SAN zips**, and all four repos take zip labels verbatim at
-train time (see {doc}`diffit`, {doc}`edm2`, {doc}`styleswin`). Classify
-every checkpoint by the dataset path in its `training_options.json` before
-comparing across models; remap with combra's `CLASS_MAP` (consumed by
-{py:func}`combra.angles.resolve_overlay_rows` and
-{py:func}`combra.angles.build_overlay_grid` as `gen_name_for_mode`) **only**
-where the audit shows the conventions actually differ.
+**Legacy artifacts (pre-0.2.0) use a different, swapped order.** The on-disk
+`imagenet_9to4_*` archives that the existing checkpoints trained on carry the
+non-alphabetical order `Ultra_Co25 → 0`, `Ultra_Co11 → 1`, `Ultra_Co6_2 → 2`
+(the `Co11`↔`Co25` swap), and they record no `class_names`. Those checkpoints
+and everything generated from them stay under combra's legacy `CLASS_MAP` until
+retrained on rebuilt zips — classify each run by the dataset path in its
+`training_options.json` before remapping. Once san-v2 is retrained on
+`san-prepare-data`-built zips, all artifacts are self-describing by name and the
+class-map warning becomes a historical note. See the {doc}`label contract
+<models_api_proposal>` (§5) and the current-state {doc}`API scheme <models_api>`.
 ```
-
-**Why the order differs.** The dataset stores only an integer label per image — never
-the `Ultra_Co*` name — and the two pipelines derive that integer by *different rules*:
-
-- **SAN** (`dataset_tool.py`) copies the label **verbatim from the preprocessed
-  source's `dataset.json`**, which was written `Ultra_Co25 → 0`, `Ultra_Co11 → 1`,
-  `Ultra_Co6_2 → 2` — an order that is **not** alphabetical.
-- **DiffiT** (`dataset_tool_for_imagenet.py`) ignores that file and re-derives labels
-  from the **alphabetical order of the class-folder names** (`sorted` then
-  `enumerate`): `Ultra_Co11 → 0`, `Ultra_Co25 → 1`, `Ultra_Co6_2 → 2`.
-
-Because the source `dataset.json` lists `Co25` before `Co11` while the folder sort puts
-`Co11` first, the two conventions disagree on labels 0 and 1 — the `Co11`↔`Co25` swap.
-`Ultra_Co6_2` is last under both rules, so it stays `2`. **Which rule a checkpoint
-follows depends on which zip it trained on** — the shipped `imagenet_9to4_*` archives
-carry the SAN-order labels, whichever tool nominally built them. Since neither pipeline
-records the grain name downstream (the zips hold neither `class_names` nor original
-filenames, and generated h5s carry only `class_0/1/2`), the correspondence has to be
-recovered per run from `training_options.json` and pinned in combra's `CLASS_MAP`.


### PR DESCRIPTION
san-v2 has implemented the models_api_proposal §12 producer changes, so update the current-state pages to match:

- san_v2.md: rewrite install (pip install -e, console scripts), dataset prep (san-prepare-data group, alphabetical labels + class_names), training (san-train, kebab-case progressive flags, --precision, no Hydra), the checkpoint scheme (.pt EMA-only inference snapshots, atomic, --snapshot-keep-last, no resume/best-model), combra eval (--num-fid-samples, mirrored to stats.jsonl), san-eval, and san-gen-images (.pt --network, --classes by name, unified h5, merge hard-fail); refresh the class-index table to the alphabetical order with a legacy warning for pre-0.2.0 artifacts.
- models_api.md: mark san-v2 (v0.2.0) as the first repo on the v2 convention and update its cells in the training/checkpoints/generation tables, the best-model/save-inference-only notes, the class-index section and the known-divergences list.


Claude-Session: https://claude.ai/code/session_01Cpc3cSGE6tyFBRf6ji7zDp