### PR TITLE
docs: sync to combra 0.5 (remove deleted symbols, frechet rename, ver…

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,7 +1,7 @@
 [
   {
-    "name": "0.4 (stable)",
-    "version": "0.4.0",
+    "name": "0.5 (stable)",
+    "version": "0.5.0",
     "url": "https://dkagramanyan.github.io/combra/",
     "preferred": true
   }

--- a/docs/api/approx.md
+++ b/docs/api/approx.md
@@ -76,49 +76,6 @@ Bimodal Gaussian fit. Bounded: `sigma > 0`, `amp ≥ 0` (prevents the silent sig
 ```
 ````
 
-````{py:function} combra.approx.gaussian_fit_termodal(x, y, mu1=10, mu2=100, mu3=240, sigma1=10, sigma2=30, sigma3=30, amp1=1, amp2=1, amp3=1) -> tuple[list[float], list[float], list[float]]
-
-Trimodal Gaussian fit.
-
-:param x: Histogram bin centres.
-:type x: array_like
-:param y: Histogram densities.
-:type y: array_like
-:param mu1: Initial guess for the first mean. Default: `10`.
-:type mu1: float, optional
-:param mu2: Initial guess for the second mean. Default: `100`.
-:type mu2: float, optional
-:param mu3: Initial guess for the third mean. Default: `240`.
-:type mu3: float, optional
-:param sigma1: Initial guess for the first sigma. Default: `10`.
-:type sigma1: float, optional
-:param sigma2: Initial guess for the second sigma. Default: `30`.
-:type sigma2: float, optional
-:param sigma3: Initial guess for the third sigma. Default: `30`.
-:type sigma3: float, optional
-:param amp1: Initial guess for the first amplitude. Default: `1`.
-:type amp1: float, optional
-:param amp2: Initial guess for the second amplitude. Default: `1`.
-:type amp2: float, optional
-:param amp3: Initial guess for the third amplitude. Default: `1`.
-:type amp3: float, optional
-:returns: **mus** (*list[float, float, float]*) – Fitted length-3 means; and **sigmas** (*list[float, float, float]*) – Fitted length-3 sigmas; and **amps** (*list[float, float, float]*) – Fitted length-3 amplitudes.
-:rtype: tuple(list[float], list[float], list[float])
-
-**Example**
-
-```python
->>> import numpy as np
->>> from combra import stats, approx
->>> arr = np.concatenate([np.random.normal(20, 5, 800),
-...                       np.random.normal(120, 25, 1500),
-...                       np.random.normal(260, 20, 1000)])
->>> x, y = stats.stats_preprocess(arr, step=2)
->>> mus, sigmas, amps = approx.gaussian_fit_termodal(x, y)
->>> print(f'mus={mus}')
-```
-````
-
 ````{py:function} combra.approx.gauss_approx(x, y, mu=1, sigma=1, amp=1, x_lim=None, N=100) -> tuple[tuple[ndarray, ndarray], float, float, float]
 
 Single Gaussian fit + sampled curve.

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -42,12 +42,6 @@ is the same function) and the angle plotters share.
 Alias of {py:func}`~combra.io.load_rows` for angle parquets.
 ````
 
-````{py:function} combra.io.load_beams(path) -> list[dict]
-
-Alias of {py:func}`~combra.io.load_rows` for beam parquets (angle and beam files
-share the `meta` / `prep_per_step` layout).
-````
-
 ## Schemas & provenance
 
 ````{py:data} combra.io.ANGLES_SCHEMA
@@ -105,12 +99,6 @@ class). Written to a temp file and renamed on full success. This is what
 :type chunk_images: int, optional
 :returns: **output_path** – the written file.
 :rtype: pathlib.Path
-````
-
-````{py:function} combra.io.repack_hdf5_uncompressed(src_path, dst_path=None, chunk_images=32, overwrite=False) -> pathlib.Path
-
-Re-pack an existing pobedit HDF5 to uncompressed, preserving all attributes. Use
-once on an LZF cache to eliminate the source-decompression bottleneck.
 ````
 
 ## See also

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -78,7 +78,7 @@ Classic InceptionV3 FID between two **in-memory image batches** (a numpy array o
 >>> print(f'FID = {fid:.4f}')
 ```
 
-A full multi-resolution loop is shown in the {doc}`FID example </examples/fid>`. `compute_fid` works from images; for sharded or distributed evaluation the feature-extraction and distance halves are exposed separately as {py:func}`combra.metrics.fid_features` / {py:func}`combra.metrics.fid_from_features` (see [Sharded feature extraction](#sharded-feature-extraction) below). combra does not expose the raw mean/covariance (`mu`/`sigma`) form directly.
+A full multi-resolution loop is shown in the {doc}`FID example </examples/fid>`. `compute_fid` works from images; for sharded or distributed evaluation the feature-extraction and distance halves are exposed separately as {py:func}`combra.metrics.fid_features` / {py:func}`combra.metrics.frechet_from_features` (see [Sharded feature extraction](#sharded-feature-extraction) below). combra does not expose the raw mean/covariance (`mu`/`sigma`) form directly.
 ````
 
 ````{py:function} combra.metrics.compute_cmmd(reference_images, generated_images, model_name='ViT-L-14-336-quickgelu', pretrained='openai', device=None, batch_size=64, sigma=10.0, scale=1000.0, reference_cache=None) -> float
@@ -142,9 +142,10 @@ Fréchet distance between the [DINOv2](https://github.com/facebookresearch/dinov
 Each image-feature metric is also exposed as **two halves** — a *feature
 extractor* (`fid_features`, `cmmd_features`, `fd_dinov2_features`) that turns an
 image batch into its backbone features, and a *distance* function
-(`fid_from_features`, `cmmd_from_features`, `fd_dinov2_from_features`) that scores
-two feature sets. The `compute_*` functions above are thin wrappers over these
-two halves, so the numbers are identical.
+(`frechet_from_features` for both Fréchet metrics — FID and FD-DINOv2 — and
+`cmmd_from_features` for CMMD) that scores two feature sets. The `compute_*`
+functions above are thin wrappers over these two halves, so the numbers are
+identical.
 
 Splitting them lets the (expensive) feature extraction be **sharded across
 devices or processes**: extract features for disjoint slices of the generated set
@@ -160,15 +161,15 @@ the (cached) reference features.
 
 ```python
 >>> import numpy as np
->>> from combra.metrics import fid_features, fid_from_features
+>>> from combra.metrics import fid_features, frechet_from_features
 >>> ref_feats = fid_features(real_batch)                       # once, cacheable
 >>> gen_feats = np.concatenate([fid_features(s) for s in gen_shards])  # sharded
->>> fid = fid_from_features(ref_feats, gen_feats)              # == compute_fid(real, gen)
+>>> fid = frechet_from_features(ref_feats, gen_feats)          # == compute_fid(real, gen)
 ```
 
 ````{py:function} combra.metrics.fid_features(images, device=None, batch_size=50, dims=2048) -> ndarray
 
-Feature half of {py:func}`combra.metrics.compute_fid`: run `images` through InceptionV3 and return the pooled activations as a float32 array `[N, dims]`. Pair with {py:func}`combra.metrics.fid_from_features`. Same `device` / `batch_size` / `dims` semantics as `compute_fid`.
+Feature half of {py:func}`combra.metrics.compute_fid`: run `images` through InceptionV3 and return the pooled activations as a float32 array `[N, dims]`. Pair with {py:func}`combra.metrics.frechet_from_features`. Same `device` / `batch_size` / `dims` semantics as `compute_fid`.
 
 :param images: Image batch (numpy array or torch tensor).
 :type images: ndarray or torch.Tensor
@@ -182,15 +183,15 @@ Feature half of {py:func}`combra.metrics.compute_fid`: run `images` through Ince
 :rtype: ndarray
 ````
 
-````{py:function} combra.metrics.fid_from_features(reference_features, generated_features) -> float
+````{py:function} combra.metrics.frechet_from_features(reference_features, generated_features) -> float
 
-Distance half of {py:func}`combra.metrics.compute_fid`: the Fréchet distance between two InceptionV3 feature sets produced by {py:func}`combra.metrics.fid_features`. Each side needs **≥ 2 rows** (it estimates a covariance).
+The distance half shared by every Fréchet-distance metric (FID and FD-DINOv2): reduce each feature set to its `(mu, sigma)` and take the Fréchet distance between the two. The backbone is irrelevant here — pair it with {py:func}`combra.metrics.fid_features` for FID or {py:func}`combra.metrics.fd_dinov2_features` for FD-DINOv2. Each side needs **≥ 2 rows** (it estimates a covariance). Pooling features from several shards before this call is exact.
 
-:param reference_features: Reference features, shape `[N, dims]`.
+:param reference_features: Reference features, shape `[N, D]`.
 :type reference_features: ndarray
-:param generated_features: Generated features, shape `[M, dims]`.
+:param generated_features: Generated features, shape `[M, D]`.
 :type generated_features: ndarray
-:returns: **fid** (*float*) – Fréchet (FID) distance.
+:returns: **fd** (*float*) – Fréchet distance between the two feature sets.
 :rtype: float
 ````
 
@@ -230,7 +231,7 @@ Distance half of {py:func}`combra.metrics.compute_cmmd`: the Gaussian-RBF MMD be
 
 ````{py:function} combra.metrics.fd_dinov2_features(images, model_name='dinov2_vitb14', device=None, batch_size=64, image_size=224) -> ndarray
 
-Feature half of {py:func}`combra.metrics.compute_fd_dinov2`: the per-image DINOv2 features as a float32 array `[N, D]`. Pair with {py:func}`combra.metrics.fd_dinov2_from_features`.
+Feature half of {py:func}`combra.metrics.compute_fd_dinov2`: the per-image DINOv2 features as a float32 array `[N, D]`. Pair with {py:func}`combra.metrics.frechet_from_features`.
 
 :param images: Image batch (numpy array or torch tensor).
 :type images: ndarray or torch.Tensor
@@ -244,18 +245,6 @@ Feature half of {py:func}`combra.metrics.compute_fd_dinov2`: the per-image DINOv
 :type image_size: int, optional
 :returns: **features** (*ndarray*) – DINOv2 features, shape `[N, D]`.
 :rtype: ndarray
-````
-
-````{py:function} combra.metrics.fd_dinov2_from_features(reference_features, generated_features) -> float
-
-Distance half of {py:func}`combra.metrics.compute_fd_dinov2`: the Fréchet distance between two DINOv2 feature sets produced by {py:func}`combra.metrics.fd_dinov2_features`. Each side needs **≥ 2 rows**.
-
-:param reference_features: Reference features, shape `[N, D]`.
-:type reference_features: ndarray
-:param generated_features: Generated features, shape `[M, D]`.
-:type generated_features: ndarray
-:returns: **fd** (*float*) – Fréchet distance between the two DINOv2 feature sets.
-:rtype: float
 ````
 
 ### Angle-Wasserstein metrics
@@ -319,7 +308,7 @@ Reduce a batch of images to a single angle density `(x, y)`. Runs `_preprocess_i
 
 ````{py:function} combra.metrics.images_to_pooled_angles(images, border_eps=5, tol=3, min_segment_len=10.0, workers=None) -> ndarray
 
-The step-independent part of {py:func}`combra.metrics.images_to_angle_density`: run `_preprocess_image → vertex_angles` on each image and concatenate the per-image vertex angles, but **without** histogramming. Histogram the result with {py:func}`combra.stats.stats_preprocess` to obtain the `(x, y)` density. Because pooling is plain concatenation and `stats_preprocess` is a `bincount`, pooled arrays from disjoint image shards combine exactly — `stats_preprocess(concat(pooled_a, pooled_b))` equals the density over the full set, in any order — so this is the unit to extract per worker/rank when the per-image angle work is sharded (see [Sharded angle metrics](#sharded-angle-metrics)).
+The step-independent part of {py:func}`combra.metrics.images_to_angle_density`: run `_preprocess_image → vertex_angles` on each image and concatenate the per-image vertex angles, but **without** histogramming. Histogram the result with {py:func}`combra.stats.stats_preprocess` to obtain the `(x, y)` density. Because pooling is plain concatenation and `stats_preprocess` is a `bincount`, pooled arrays from disjoint image shards combine exactly — `stats_preprocess(concat(pooled_a, pooled_b))` equals the density over the full set, in any order — so this is the unit to extract per worker/rank when the per-image angle work is sharded.
 
 :param images: Image batch.
 :type images: ndarray or torch.Tensor
@@ -376,75 +365,6 @@ Bimodal-Gaussian relative-error metrics between a reference and a generated samp
 The density-level core (used by the parquet comparison path) lives at `combra.metrics.gauss.gauss_density_metrics`; the raw per-mode error math, shared with `compute_metrics`, is `combra.metrics.gauss.gauss_relative_errors`.
 ````
 
-#### Single-parameter wrappers
-
-When you want just one of the six Gaussian metrics, each has a dedicated function that returns that scalar directly. They take the **same inputs and options** as `compute_gauss_metrics` (single image, batch, or `(x, y)` density; `step`, `reference_cache`, `**angle_kw`) and simply return one value from it — so `compute_mu1(ref, gen)` is exactly `compute_gauss_metrics(ref, gen)['mu1']`. Each returns `(generated − reference) / reference` for the named fitted parameter; **mode 1** is the lower-angle Gaussian, **mode 2** the higher-angle one. When you need **several** of them, call `compute_gauss_metrics` once instead — it fits each side only once, whereas the wrappers refit per call.
-
-````{py:function} combra.metrics.compute_mu1(reference, generated, step=None, reference_cache=None, **angle_kw) -> float
-
-Relative error of the **mode-1 Gaussian mean** — the `mu1` value of {py:func}`combra.metrics.compute_gauss_metrics`. `reference` and `generated` may each be a single `(H, W)` image, a batch, or a precomputed `(x, y)` density.
-
-:param reference: Reference sample — image, image batch, or `(x, y)` density.
-:type reference: ndarray or torch.Tensor or tuple
-:param generated: Generated sample to score — image, image batch, or `(x, y)` density.
-:type generated: ndarray or torch.Tensor or tuple
-:param step: Histogram bin width in degrees (image input only). Defaults to `5.0`. Default: `None`.
-:type step: float or None, optional
-:param reference_cache: Opt-in dict memoising the reference angle density across calls. Default: `None`.
-:type reference_cache: dict or None, optional
-:param angle_kw: Extra keyword args forwarded to `images_to_angle_density` (`border_eps`, `tol`, `min_segment_len`).
-:returns: **mu1** (*float*) – `(generated − reference) / reference` for the mode-1 fitted mean.
-:rtype: float
-
-**Example**
-
-```python
->>> from combra.metrics import compute_mu1
->>> compute_mu1(real_batch, generated_batch)      # relative error of the mode-1 mean
->>> compute_mu1(real_image, generated_image)      # single images are fine too
-```
-````
-
-````{py:function} combra.metrics.compute_mu2(reference, generated, step=None, reference_cache=None, **angle_kw) -> float
-
-Relative error of the **mode-2 Gaussian mean** — the `mu2` value of {py:func}`combra.metrics.compute_gauss_metrics`. Same inputs and options as {py:func}`combra.metrics.compute_mu1`.
-
-:returns: **mu2** (*float*) – `(generated − reference) / reference` for the mode-2 fitted mean.
-:rtype: float
-````
-
-````{py:function} combra.metrics.compute_sigma1(reference, generated, step=None, reference_cache=None, **angle_kw) -> float
-
-Relative error of the **mode-1 Gaussian width** — the `sigma1` value of {py:func}`combra.metrics.compute_gauss_metrics`. Same inputs and options as {py:func}`combra.metrics.compute_mu1`.
-
-:returns: **sigma1** (*float*) – `(generated − reference) / reference` for the mode-1 fitted width.
-:rtype: float
-````
-
-````{py:function} combra.metrics.compute_sigma2(reference, generated, step=None, reference_cache=None, **angle_kw) -> float
-
-Relative error of the **mode-2 Gaussian width** — the `sigma2` value of {py:func}`combra.metrics.compute_gauss_metrics`. Same inputs and options as {py:func}`combra.metrics.compute_mu1`.
-
-:returns: **sigma2** (*float*) – `(generated − reference) / reference` for the mode-2 fitted width.
-:rtype: float
-````
-
-````{py:function} combra.metrics.compute_amp1(reference, generated, step=None, reference_cache=None, **angle_kw) -> float
-
-Relative error of the **mode-1 Gaussian amplitude** — the `amp1` value of {py:func}`combra.metrics.compute_gauss_metrics`. Same inputs and options as {py:func}`combra.metrics.compute_mu1`.
-
-:returns: **amp1** (*float*) – `(generated − reference) / reference` for the mode-1 fitted amplitude.
-:rtype: float
-````
-
-````{py:function} combra.metrics.compute_amp2(reference, generated, step=None, reference_cache=None, **angle_kw) -> float
-
-Relative error of the **mode-2 Gaussian amplitude** — the `amp2` value of {py:func}`combra.metrics.compute_gauss_metrics`. Same inputs and options as {py:func}`combra.metrics.compute_mu1`.
-
-:returns: **amp2** (*float*) – `(generated − reference) / reference` for the mode-2 fitted amplitude.
-:rtype: float
-````
-
 ### Unified entry point
 
 ````{py:function} combra.metrics.compute_all_metrics(reference_images, generated_images, *, step=None, device=None, angle_kw=None, reference_cache=None, image_metrics=False, workers=None) -> dict
@@ -477,32 +397,6 @@ Run every requested batch metric for a (reference, generated) pair in parallel a
 >>> scores = compute_all_metrics(real_batch, generated_batch, image_metrics=True)
 >>> scores['cmmd'], scores['w1'], scores['mu1']
 ```
-````
-
-### Sharded angle metrics
-
-Just as the image-feature metrics split into [extractor + distance halves](#sharded-feature-extraction), the angle suite splits into {py:func}`combra.metrics.images_to_pooled_angles` (the expensive, per-image extraction) and `angle_density_metrics_from_pooled` (the cheap histogram + Wasserstein + Gaussian-fit assembly). This lets the angle extraction be **sharded across devices or processes**: pool the angles for disjoint slices in parallel, concatenate the 1-D arrays, then compute the metrics once. Pooling is plain concatenation and the histogram is a `bincount`, so the sharded result is **exact**, not an approximation — identical to `compute_all_metrics(..., image_metrics=False)` over the full set. The model training loops (DiffiT-v2, EDM2-v2, san-v2, StyleSwin-v2) use this (alongside the sharded features) so the angle work — for both the generated and the reference set — is spread over every rank instead of running on rank 0 (see the {doc}`DiffiT example </examples/diffit>`).
-
-```python
->>> import numpy as np
->>> from combra.metrics import images_to_pooled_angles, angle_density_metrics_from_pooled
->>> ref_ang = images_to_pooled_angles(real_batch)                          # once, cacheable
->>> gen_ang = np.concatenate([images_to_pooled_angles(s) for s in gen_shards])  # sharded
->>> m = angle_density_metrics_from_pooled(ref_ang, gen_ang)  # == compute_all_metrics(..., image_metrics=False)
-```
-
-````{py:function} combra.metrics.angle_density_metrics_from_pooled(reference_angles, generated_angles, step=None) -> dict
-
-Angle-density metrics from pre-pooled angle arrays — the distributed-friendly counterpart of `compute_all_metrics(image_metrics=False)`. Callers that sharded {py:func}`combra.metrics.images_to_pooled_angles` across workers/ranks gather the pooled arrays and pass them here. Histograms each side at `step` degrees with {py:func}`combra.stats.stats_preprocess` and returns the same angle-suite keys as {py:func}`combra.metrics.compute_all_metrics` — the Wasserstein `w1`/`w2`/`circular_w1`/`circular_w2` and the bimodal-Gaussian relative errors `mu1`/`mu2`/`sigma1`/`sigma2`/`amp1`/`amp2`.
-
-:param reference_angles: 1-D pooled reference angles, as returned by {py:func}`combra.metrics.images_to_pooled_angles`.
-:type reference_angles: ndarray
-:param generated_angles: 1-D pooled generated angles.
-:type generated_angles: ndarray
-:param step: Histogram bin width in degrees. Defaults to `5.0`. Default: `None`.
-:type step: float or None, optional
-:returns: **results** (*dict*) – Flat `{metric_name: value}` dict with keys `w1`, `w2`, `circular_w1`, `circular_w2`, `mu1`, `mu2`, `sigma1`, `sigma2`, `amp1`, `amp2`.
-:rtype: dict
 ````
 
 ## Startup check & normalization

--- a/docs/api/stats.md
+++ b/docs/api/stats.md
@@ -90,47 +90,6 @@ Sum of two Gaussians. Use {py:func}`combra.approx.bimodal_gauss_approx` to fit i
 ```
 ````
 
-````{py:function} combra.stats.gaussian_termodal(x, mu1, mu2, mu3, sigma1, sigma2, sigma3, amp1=1, amp2=1, amp3=1) -> ndarray
-
-Sum of three Gaussians.
-
-:param x: Evaluation points.
-:type x: array_like
-:param mu1: First mean.
-:type mu1: float
-:param mu2: Second mean.
-:type mu2: float
-:param mu3: Third mean.
-:type mu3: float
-:param sigma1: First standard deviation.
-:type sigma1: float
-:param sigma2: Second standard deviation.
-:type sigma2: float
-:param sigma3: Third standard deviation.
-:type sigma3: float
-:param amp1: First amplitude. Default: `1`.
-:type amp1: float, optional
-:param amp2: Second amplitude. Default: `1`.
-:type amp2: float, optional
-:param amp3: Third amplitude. Default: `1`.
-:type amp3: float, optional
-:returns: **y** (*ndarray*) – Function values at `x`.
-:rtype: ndarray
-
-**Example**
-
-```python
->>> import numpy as np
->>> from combra import stats
->>> x = np.linspace(0, 360, 200)
->>> y = stats.gaussian_termodal(
-...     x, mu1=30, mu2=180, mu3=300,
-...     sigma1=15, sigma2=25, sigma3=20,
-...     amp1=0.6, amp2=1.0, amp3=0.5,
-... )
-```
-````
-
 ````{py:function} combra.stats.ellipse(a, b, angle, xc=0, yc=0, num=50) -> tuple[ndarray, ndarray]
 
 Sample `num` points on the ellipse with semi-axes `(a, b)`, rotation `angle` (radians, decreasing → clockwise), and centre `(xc, yc)`. Handy for overlaying MVEE results.

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -30,32 +30,3 @@ self-describing (`ds.images`, `ds.class_names`) while still behaving as a plain
 True
 ```
 ````
-
-## NumpyEncoder
-
-````{py:class} combra.utils.NumpyEncoder(json.JSONEncoder)
-
-A `json.JSONEncoder` subclass that handles numpy scalars and arrays. Use it whenever you need to dump combra outputs to JSON without converting types by hand.
-
-**Handles**
-
-- **`np.float32`, `np.float64`** — serialised as Python `float`.
-- **`np.int32`, `np.int64`** — serialised as Python `int`.
-- **`np.ndarray`** — serialised as nested `list` (via `tolist()`).
-- **anything else** — falls through to the default `json.JSONEncoder` (raises `TypeError` for unsupported types).
-
-**Example**
-
-```python
->>> import json
->>> import numpy as np
->>> from combra.utils import NumpyEncoder
->>> payload = {
-...     'mus': np.array([90.5, 270.3]),
-...     'count': np.int64(42),
-...     'score': np.float32(0.97),
-... }
->>> with open('out.json', 'w') as f:
-...     json.dump(payload, f, cls=NumpyEncoder)
-```
-````

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,8 @@ import os
 project = "combra"
 copyright = "2026, D.G.Kagramanyan"
 author = "D.G.Kagramanyan"
-release = "0.4.0"
-version = "0.4"
+release = "0.5.0"
+version = "0.5"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/examples/diffit.md
+++ b/docs/examples/diffit.md
@@ -166,10 +166,9 @@ metrics are computed once against the reference. The reference side is sharded t
 same way and extracted **once before training** (each rank processes its
 deterministic slice of the reals), then cached on rank 0 — so no reference work or
 collective recurs per tick. This uses combra's split APIs — the feature halves
-({py:func}`combra.metrics.fid_features` + {py:func}`combra.metrics.fid_from_features`
-and the `cmmd_*` / `fd_dinov2_*` analogues) and the angle halves
-({py:func}`combra.metrics.images_to_pooled_angles` +
-`angle_density_metrics_from_pooled`) — and is numerically identical to the
+({py:func}`combra.metrics.fid_features` + {py:func}`combra.metrics.frechet_from_features`
+and the `cmmd_*` / `fd_dinov2_*` analogues) and the pooled-angle extractor
+({py:func}`combra.metrics.images_to_pooled_angles`) — and is numerically identical to the
 single-GPU `compute_all_metrics` path. Sharding the angle extraction this way also
 fixes a multi-GPU hang: when it ran rank-0-only over the full gathered batch, at
 512²/1024² it could take longer than NCCL's watchdog while the other ranks idled,

--- a/docs/examples/edm2.md
+++ b/docs/examples/edm2.md
@@ -161,10 +161,9 @@ distances and the angle metrics are computed once against the reference. The
 reference side is the **raw dataset pixels** (never VAE round-tripped), extracted
 **once before training** (each rank processes its deterministic slice of the reals),
 then cached on rank 0. This uses combra's split APIs
-({py:func}`combra.metrics.fid_features` + {py:func}`combra.metrics.fid_from_features`
+({py:func}`combra.metrics.fid_features` + {py:func}`combra.metrics.frechet_from_features`
 and the `cmmd_*` / `fd_dinov2_*` analogues, plus
-{py:func}`combra.metrics.images_to_pooled_angles` +
-`angle_density_metrics_from_pooled`) — numerically identical to the single-GPU
+{py:func}`combra.metrics.images_to_pooled_angles`) — numerically identical to the single-GPU
 `compute_all_metrics` path.
 
 **Sample count.** Each combra eval scores `--num-fid-samples` generated images

--- a/docs/examples/models_api.md
+++ b/docs/examples/models_api.md
@@ -50,9 +50,8 @@ Every repo follows the same conventions:
   `true`): every snapshot tick, fakes are generated **sharded across all ranks**
   and scored against the training set (reference features precomputed once) using
   combra's split APIs — {py:func}`combra.metrics.fid_features` /
-  `fid_from_features`, the `cmmd_*` / `fd_dinov2_*` analogues, and
-  {py:func}`combra.metrics.images_to_pooled_angles` +
-  `angle_density_metrics_from_pooled` — numerically equivalent to a single-GPU
+  `frechet_from_features`, the `cmmd_*` / `fd_dinov2_*` analogues, and
+  {py:func}`combra.metrics.images_to_pooled_angles` — numerically equivalent to a single-GPU
   {py:func}`combra.metrics.compute_all_metrics` call. Results are mirrored into
   **both** TensorBoard (`Metrics/combra_fid10k`, `Metrics/combra_cmmd10k`,
   `Metrics/combra_fd_dinov2_10k` + the angle metrics) and `stats.jsonl` in all

--- a/docs/examples/models_api_proposal.md
+++ b/docs/examples/models_api_proposal.md
@@ -345,8 +345,8 @@ One eval pass per snapshot tick, identical in all four repos:
    `fd_dinov2`), the CLIP MMD (`cmmd`) and the angle-density metrics
    (Wasserstein `w1`/`w2`/`circular_*` + bimodal-Gaussian fit errors) against
    the cached reference
-   ({py:func}`combra.metrics.fid_from_features` + analogues,
-   `angle_density_metrics_from_pooled`).
+   ({py:func}`combra.metrics.frechet_from_features` + analogues,
+   {py:func}`combra.metrics.images_to_pooled_angles`).
 4. **Logging.** Results land in TensorBoard as `Metrics/combra_*` and in
    `stats.jsonl`. A metric whose backend is unavailable (e.g. no network for
    DINOv2 weights) records `nan`; a missing combra package prints a startup

--- a/docs/examples/san_v2.md
+++ b/docs/examples/san_v2.md
@@ -148,10 +148,9 @@ each rank generates its shard of the fakes, extracts the CLIP / DINOv2 / Incepti
 features and pools the vertex angles; the feature rows and pooled-angle arrays are
 gathered to rank 0, which takes the Fréchet / MMD distances and the angle metrics
 against the cached reference. This uses combra's split APIs — the feature halves
-({py:func}`combra.metrics.fid_features` + {py:func}`combra.metrics.fid_from_features`,
-and the `cmmd_*` / `fd_dinov2_*` analogues) and the angle halves
-({py:func}`combra.metrics.images_to_pooled_angles` +
-`angle_density_metrics_from_pooled`) — and is numerically identical to the
+({py:func}`combra.metrics.fid_features` + {py:func}`combra.metrics.frechet_from_features`,
+and the `cmmd_*` / `fd_dinov2_*` analogues) and the pooled-angle extractor
+({py:func}`combra.metrics.images_to_pooled_angles`) — and is numerically identical to the
 single-GPU `compute_all_metrics(image_metrics=True)` path. Any metric whose optional
 backend is unavailable (e.g. no network to fetch DINOv2/CLIP weights) is recorded as
 `nan` rather than aborting. Pre-download the weights once on a login node with

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -103,4 +103,4 @@ The output file's `run_meta` column records who/when/what — including the git 
 | {doc}`combra.approx <api/approx>` | Fits Gaussian/binomial/poisson/exponential/linear models. |
 | {doc}`combra.metrics <api/metrics>` | FID, batch generative-quality metrics (CMMD, FD-DINOv2, angle-Wasserstein), per-class Wasserstein comparison, sampler-vs-steps comparison, and convergence-vs-N analysis (Kendall trend, plateau fit, gain-distribution plot). |
 | {doc}`combra.graph <api/graph>` | Crack-image → graph → shortest-energy-path search. |
-| {doc}`combra.utils <api/utils>` | `NumpyEncoder` for JSON dumps. |
+| {doc}`combra.utils <api/utils>` | `Bunch` attribute-accessible dict container. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,8 +63,8 @@ examples/sampler_comparison
 | {doc}`combra.approx <api/approx>` | Fits Gaussian/binomial/poisson/exponential/linear models. |
 | {doc}`combra.metrics <api/metrics>` | FID, batch generative-quality metrics (CMMD, FD-DINOv2, angle-Wasserstein), per-class Wasserstein comparison, sampler-vs-steps comparison, and convergence-vs-N analysis. |
 | {doc}`combra.graph <api/graph>` | Crack-image → graph → shortest-energy-path search. |
-| {doc}`combra.io <api/io>` | One loader (`load_angles`/`load_beams`) + parquet schemas + HDF5 conversion. |
+| {doc}`combra.io <api/io>` | One loader (`load_rows`/`load_angles`) + parquet schemas + HDF5 conversion. |
 | {doc}`combra.viz <api/viz>` | Shared plotting theme: palette, axis style, PNG export. |
 | {doc}`combra.exceptions <api/exceptions>` | Typed error/warning hierarchy (`CombraError`, `SchemaError`, …). |
-| {doc}`combra.utils <api/utils>` | `NumpyEncoder` for JSON dumps. |
+| {doc}`combra.utils <api/utils>` | `Bunch` attribute-accessible dict container. |
 | {doc}`combra.tests <api/tests>` | Self-validation helpers (fractal-dimension sanity check). |


### PR DESCRIPTION
…sion bump)

Updates the hand-authored API pages and examples for combra 0.5:
- removes the doc blocks for symbols deleted in combra (repack_hdf5_uncompressed, load_beams, NumpyEncoder, gaussian_fit_termodal/gaussian_termodal, the six compute_mu1..amp2 wrappers, angle_density_metrics_from_pooled)
- replaces fid_from_features / fd_dinov2_from_features with the single frechet_from_features across api/metrics.md and the examples
- bumps release/version to 0.5.0 and the version switcher

Full -W --keep-going build is green.


Claude-Session: https://claude.ai/code/session_015ezpdfRYD55kVMjXT4t34f